### PR TITLE
optimize init health check and pod monitor

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -212,3 +212,7 @@ func GetComposeHttpTimeout() int {
 func EnableDebugMode() bool {
 	return GetConfig().GetBool(DEBUG_MODE)
 }
+
+func IsService() bool {
+	return GetConfig().GetBool(types.IS_SERVICE)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -18,16 +18,14 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
-
 	"os"
 	"path/filepath"
-
-	"fmt"
-
 	"time"
 
 	"github.com/paypal/dce-go/types"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -52,7 +50,7 @@ const (
 	CLEAN_IMAGE_ON_MESOS_KILL            = "cleanimageonmesoskill"
 	DOCKER_COMPOSE_VERBOSE               = "dockercomposeverbose"
 	SKIP_PULL_IMAGES                     = "launchtask.skippull"
-	DISABLE_TRACE_MODE                   = "launchtask.disabletrace"
+	COMPOSE_TRACE                        = "launchtask.composetrace"
 	DEBUG_MODE                           = "launchtask.debug"
 	COMPOSE_HTTP_TIMEOUT                 = "launchtask.composehttptimeout"
 )
@@ -199,8 +197,8 @@ func SkipPullImages() bool {
 	return GetConfig().GetBool(SKIP_PULL_IMAGES)
 }
 
-func DisableTraceMode() bool {
-	return GetConfig().GetBool(DISABLE_TRACE_MODE)
+func EnableComposeTrace() bool {
+	return GetConfig().GetBool(COMPOSE_TRACE)
 }
 
 func GetPollInterval() int {
@@ -213,14 +211,4 @@ func GetComposeHttpTimeout() int {
 
 func EnableDebugMode() bool {
 	return GetConfig().GetBool(DEBUG_MODE)
-}
-
-func SwitchDebugMode() {
-	if EnableDebugMode() {
-		GetConfig().Set(DEBUG_MODE, false)
-		log.Println("Turn off debug mode")
-	} else {
-		GetConfig().Set(DEBUG_MODE, true)
-		log.Println("Turn on debug mode")
-	}
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@ launchtask:
    retryinterval: 10000
    timeout: 500000
    skippull: true
-   disabletrace: false
+   composetrace: true
    debug: false
 plugins:
    pluginorder: general

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,8 @@ launchtask:
    retryinterval: 10000
    timeout: 500000
    skippull: true
+   disabletrace: false
+   debug: false
 plugins:
    pluginorder: general
 cleanpod:

--- a/dce/main.go
+++ b/dce/main.go
@@ -81,6 +81,10 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 	json.Indent(buf, task, "", " ")
 	fmt.Println("taskInfo : ", buf)
 
+	isService := pod.IsService(taskInfo)
+	fmt.Printf("task is service: %v\n", isService)
+	config.GetConfig().Set(types.IS_SERVICE, isService)
+
 	logger = log.WithFields(log.Fields{
 		"requuid":   pod.GetLabel("requuid", taskInfo),
 		"tenant":    pod.GetLabel("tenant", taskInfo),

--- a/dce/main.go
+++ b/dce/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -42,6 +41,9 @@ import (
 
 	"context"
 	"errors"
+
+	"os/signal"
+	"syscall"
 
 	"github.com/paypal/dce-go/utils"
 )
@@ -109,6 +111,8 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 		logger.Errorln("Error creating app folder")
 	}
 
+	// Create context with timeout
+	// Wait for pod launching until timeout
 	var ctx context.Context
 	var cancel context.CancelFunc
 	ctx = context.Background()
@@ -128,7 +132,7 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 
 	// Executing PreLaunchTask in order
 	_, err = utils.PluginPanicHandler(utils.ConditionFunc(func() (string, error) {
-		for _, ext := range extpoints {
+		for i, ext := range extpoints {
 			if ext == nil {
 				logger.Errorln("Error getting plugins from plugin registration pools")
 				return "", errors.New("plugin is nil")
@@ -137,6 +141,9 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 			if err != nil {
 				logger.Errorf("Error executing PreLaunchTask of plugin : %v\n", err)
 				return "", err
+			}
+			if !config.DisableTraceMode() {
+				fileUtils.DumpPluginModifiedComposeFiles(ctx, pluginOrder[i], i)
 			}
 		}
 		return "", err
@@ -148,17 +155,20 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 		return
 	}
 
+	// Service list from all compose files
 	podServices := getServices(ctx)
-	log.Printf("pod service list: %v", podServices)
+	logger.Printf("pod service list: %v", podServices)
 
+	// Write updated compose files into pod folder
 	err = fileUtils.WriteChangeToFiles(ctx)
 	if err != nil {
-		log.Errorf("Failure writing updated compose files : %v", err)
+		logger.Errorf("Failure writing updated compose files : %v", err)
 		pod.SetPodStatus(types.POD_FAILED)
 		cancel()
 		pod.SendMesosStatus(driver, taskInfo.GetTaskId(), mesos.TaskState_TASK_FAILED.Enum())
 	}
 
+	// Pulling image and launch pod
 	replyPodStatus := pullAndLaunchPod()
 
 	logger.Printf("Pod status returned by pullAndLaunchPod : %v", replyPodStatus)
@@ -213,6 +223,12 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 				pod.SendPodStatus(types.POD_RUNNING)
 				go monitor.MonitorPoller()
 			}
+		}
+
+		//For adhoc job, send finished to mesos if job already finished during init health check
+		if res == types.POD_FINISHED {
+			cancel()
+			pod.SendPodStatus(types.POD_FINISHED)
 		}
 
 	default:
@@ -300,13 +316,8 @@ func (exec *dockerComposeExecutor) Error(driver exec.ExecutorDriver, err string)
 func pullAndLaunchPod() string {
 	logger.Println("====================Pod Pull And Launch====================")
 
-	pt, err := strconv.Atoi(config.GetConfigSection(config.LAUNCH_TASK)[config.POD_MONITOR_INTERVAL])
-	if err != nil {
-		logger.Fatalf("Error converting podmonitorinterval from string to int : %s\n", err.Error())
-	}
-
 	if !config.SkipPullImages() {
-		err = wait.PollRetry(config.GetPullRetryCount(), time.Duration(pt)*time.Millisecond, wait.ConditionFunc(func() (string, error) {
+		err := wait.PollRetry(config.GetPullRetryCount(), time.Duration(config.GetPollInterval())*time.Millisecond, wait.ConditionFunc(func() (string, error) {
 			return "", pod.PullImage(pod.ComposeFiles)
 		}))
 
@@ -348,10 +359,30 @@ func getServices(ctx context.Context) map[string]bool {
 func init() {
 	flag.Parse()
 	log.SetOutput(os.Stdout)
+
+	// Set log to debug level when trace mode is turned on
+	if config.EnableDebugMode() {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
 }
 
 func main() {
 	fmt.Println("====================Genesis Executor (Go)====================")
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGUSR1)
+	go func() {
+		for {
+			sig := <-sig
+			fmt.Printf("Received signal %s\n", sig.String())
+			if sig == syscall.SIGUSR1 {
+				fmt.Println("switch debug mode")
+				config.SwitchDebugMode()
+			}
+		}
+	}()
 
 	dConfig := exec.DriverConfig{
 		Executor: newDockerComposeExecutor(),

--- a/dce/monitor/monitor.go
+++ b/dce/monitor/monitor.go
@@ -20,7 +20,6 @@ import (
 
 	"fmt"
 
-	"strconv"
 	"time"
 
 	"github.com/paypal/dce-go/config"
@@ -30,118 +29,104 @@ import (
 )
 
 // Watching pod status and notifying executor if any container in the pod goes wrong
-func podMonitor() string {
+
+func podMonitor(systemProxyId string) string {
+	logger := log.WithFields(log.Fields{
+		"func": "monitor.podMonitor",
+	})
+
 	var err error
 
 	for i := 0; i < len(pod.PodContainers); i++ {
 		var healthy string
 		var exitCode int
+		var running bool
+
+		// Set log to debug level when trace mode is turned on
+		if config.EnableDebugMode() {
+			log.SetLevel(log.DebugLevel)
+		} else {
+			log.SetLevel(log.InfoLevel)
+		}
 
 		if hc, ok := pod.HealthCheckListId[pod.PodContainers[i]]; ok && hc {
-			healthy, exitCode, err = pod.CheckContainer(pod.PodContainers[i], true)
-			//log.Printf("container %s has health check, health status: %s, exitCode: %d, err : %v", containers[i], healthy, exitCode, err)
+			healthy, running, exitCode, err = pod.CheckContainer(pod.PodContainers[i], true)
+			logger.Debugf("container %s has health check, health status: %s, exitCode: %d, err : %v",
+				pod.PodContainers[i], healthy, exitCode, err)
 		} else {
-			healthy, exitCode, err = pod.CheckContainer(pod.PodContainers[i], false)
-			//log.Printf("container %s no health check, exitCode: %d, err : %v", containers[i], healthy, exitCode, err)
+			healthy, running, exitCode, err = pod.CheckContainer(pod.PodContainers[i], false)
+			log.Debugf("container %s doesn't have health check, status: %s, exitCode: %d, err : %v",
+				pod.PodContainers[i], healthy, exitCode, err)
 		}
 
 		if err != nil {
-			log.Println(fmt.Sprintf("POD_MONITOR_HEALTH_CHECK_FAILED -- Error inspecting container with id : %s, %v", pod.PodContainers[i], err.Error()))
-			log.Println("POD_MONITOR_FAILED -- Send Failed")
+			logger.Errorf(fmt.Sprintf("POD_MONITOR_HEALTH_CHECK_FAILED -- Error inspecting container with id : %s, %v", pod.PodContainers[i], err.Error()))
+			logger.Errorln("POD_MONITOR_FAILED -- Send Failed")
 			return types.POD_FAILED
 		}
 
-		if exitCode != 0 && exitCode != -1 {
-			log.Println("POD_MONITOR_APP_EXIT -- Stop pod monitor and send Failed")
+		if exitCode != 0 {
+			logger.Println("POD_MONITOR_APP_EXIT -- Stop pod monitor and send Failed")
 			return types.POD_FAILED
 		}
 
 		if healthy == types.UNHEALTHY {
 			if config.GetConfigSection(config.CLEANPOD) == nil ||
 				config.GetConfigSection(config.CLEANPOD)[types.UNHEALTHY] == "true" {
-				log.Println("POD_MONITOR_HEALTH_CHECK_FAILED -- Stop pod monitor and send Failed")
+				logger.Println("POD_MONITOR_HEALTH_CHECK_FAILED -- Stop pod monitor and send Failed")
 				return types.POD_FAILED
 			}
-			log.Warnf("Container %s became unhealthy, but pod won't be killed due to cleanpod config", pod.PodContainers[i])
+			logger.Warnf("Container %s became unhealthy, but pod won't be killed due to cleanpod config", pod.PodContainers[i])
 		}
 
-		if exitCode == 0 {
-			log.Printf("Removed finished(exit with 0) container %s from monitor list", pod.PodContainers[i])
+		if exitCode == 0 && !running {
+			logger.Printf("Removed finished(exit with 0) container %s from monitor list", pod.PodContainers[i])
 			pod.PodContainers = append(pod.PodContainers[:i], pod.PodContainers[i+1:]...)
 			i--
 
 		}
 	}
 
-	if len(pod.PodContainers) == 0 {
-		log.Println("Pod Monitor : Finished")
+	// Send finished to mesos IF no container running or ONLY system proxy is running in the pod
+	if len(pod.PodContainers) == 0 || len(pod.PodContainers) == 1 && pod.PodContainers[0] == systemProxyId {
+		logger.Println("Pod Monitor : Finished")
 		return types.POD_FINISHED
 	}
 
-	/*var healthCount int
-	containers := make([]string, len(pod.PodContainers))
-	copy(containers, pod.PodContainers)
-
-		for i := 0; i < len(containers); i++ {
-		var healthy string
-		var exitCode int
-
-		if hc, ok := pod.HealthCheckListId[containers[i]]; ok && hc {
-			healthy, exitCode, err = pod.CheckContainer(containers[i], true)
-			//log.Printf("container %s has health check, health status: %s, exitCode: %d, err : %v", containers[i], healthy, exitCode, err)
-		} else {
-			healthy, exitCode, err = pod.CheckContainer(containers[i], false)
-			//log.Printf("container %s no health check, exitCode: %d, err : %v", containers[i], healthy, exitCode, err)
-		}
-
-		if err != nil {
-			log.Println(fmt.Sprintf("Error inspecting container with id : %s, %v", containers[i], err.Error()))
-			log.Println("Pod Monitor : Send Failed")
-			return types.POD_FAILED
-		}
-
-		if exitCode != 0 && exitCode != -1 {
-			log.Println("Pod Monitor : Stopped and send Failed")
-			return types.POD_FAILED
-		}
-
-		if healthy == types.UNHEALTHY {
-			if config.GetConfigSection(config.CLEANPOD) == nil ||
-				config.GetConfigSection(config.CLEANPOD)[types.UNHEALTHY] == "true" {
-				log.Println("Pod Monitor : Stopped and send Failed")
-				return types.POD_FAILED
-			}
-			log.Warnf("Container %s became unhealthy, but pod won't be killed due to cleanpod config", containers[i])
-		}
-
-		if exitCode == 0 || exitCode == -1 {
-			containers = append(containers[:i], containers[i+1:]...)
-			i--
-		}*/
-
-	//}
 	return ""
 }
 
 // Polling pod monitor periodically
 func MonitorPoller() {
-	log.Println("====================Pod Monitor Poller====================")
+	logger := log.WithFields(log.Fields{
+		"func": "monitor.MonitorPoller",
+	})
 
-	gap, err := strconv.Atoi(config.GetConfigSection(config.LAUNCH_TASK)[config.POD_MONITOR_INTERVAL])
-	if err != nil {
-		log.Errorf("Error converting podmonitorinterval from string to int : %s", err.Error())
-		gap = 10000
+	logger.Println("====================Pod Monitor Poller====================")
+
+	// Get infra container id
+	var infraContainerId string
+	var err error
+	if !config.GetConfig().GetBool(types.RM_INFRA_CONTAINER) {
+		infraContainerId, err = pod.GetContainerIdByService(pod.ComposeFiles, types.INFRA_CONTAINER)
+		if err != nil {
+			logger.Errorf("Error getting container id of service %s: %v", types.INFRA_CONTAINER, err)
+			logger.Errorln("POD_MONITOR_FAILED -- Send Failed")
+			pod.SendPodStatus(types.POD_FAILED)
+			return
+		}
+		logger.Printf("Infra container id: %s", infraContainerId)
 	}
 
-	res, err := wait.PollForever(time.Duration(gap)*time.Millisecond, nil, wait.ConditionFunc(func() (string, error) {
-		return podMonitor(), nil
+	res, err := wait.PollForever(time.Duration(config.GetPollInterval())*time.Millisecond, nil, wait.ConditionFunc(func() (string, error) {
+		return podMonitor(infraContainerId), nil
 	}))
 
-	log.Printf("Pod Monitor Receiver : Received  message %s", res)
+	logger.Printf("Pod Monitor Receiver : Received  message %s", res)
 
 	curntPodStatus := pod.GetPodStatus()
 	if curntPodStatus == types.POD_KILLED || curntPodStatus == types.POD_FAILED {
-		log.Println("====================Pod Monitor Stopped====================")
+		logger.Println("====================Pod Monitor Stopped====================")
 		return
 	}
 
@@ -156,7 +141,5 @@ func MonitorPoller() {
 
 	case types.POD_FINISHED:
 		pod.SendPodStatus(types.POD_FINISHED)
-
 	}
-
 }

--- a/plugin/general/editor.go
+++ b/plugin/general/editor.go
@@ -16,19 +16,18 @@ package general
 
 import (
 	"container/list"
+	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"fmt"
-
-	"context"
 
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/types"
 	utils "github.com/paypal/dce-go/utils/file"
 	"github.com/paypal/dce-go/utils/pod"
+
 	log "github.com/sirupsen/logrus"
 )
 

--- a/plugin/general/editor.go
+++ b/plugin/general/editor.go
@@ -35,8 +35,6 @@ import (
 const (
 	PORT_DELIMITER = ":"
 	PATH_DELIMITER = "/"
-	NETWORK_PROXY  = "networkproxy"
-	ENVIRONMENT    = "environment"
 )
 
 func EditComposeFile(ctx *context.Context, file string, executorId string, taskId string, ports *list.Element) (string, *list.Element, error) {
@@ -69,6 +67,8 @@ func EditComposeFile(ctx *context.Context, file string, executorId string, taskI
 		file = file + utils.FILE_POSTFIX
 	}
 	*ctx = context.WithValue(*ctx, types.SERVICE_DETAIL, filesMap)
+
+	logger.Printf("Updated compose files, current context: %v\n", filesMap)
 	return file, ports, err
 }
 
@@ -90,11 +90,11 @@ func UpdateServiceSessions(serviceName, file, executorId, taskId string, filesMa
 
 	// Get env list
 	var envIsArray bool
-	envMap, ok := containerDetails[ENVIRONMENT].(map[interface{}]interface{})
+	envMap, ok := containerDetails[types.ENVIRONMENT].(map[interface{}]interface{})
 	if ok {
 		logger.Printf("ENV is an array %v of %s : %v", envIsArray, serviceName, envMap)
 	}
-	envList, ok := containerDetails[ENVIRONMENT].([]interface{})
+	envList, ok := containerDetails[types.ENVIRONMENT].([]interface{})
 	if ok {
 		logger.Printf("ENV is an array %v of %s : %v", envIsArray, serviceName, envList)
 		envIsArray = true
@@ -105,18 +105,18 @@ func UpdateServiceSessions(serviceName, file, executorId, taskId string, filesMa
 
 	if envIsArray {
 		envList = append(envList, fmt.Sprintf("%s=%d", "PYTHONUNBUFFERED", 1))
-		containerDetails[ENVIRONMENT] = envList
+		containerDetails[types.ENVIRONMENT] = envList
 	} else {
 		envMap["PYTHONUNBUFFERED"] = 1
-		containerDetails[ENVIRONMENT] = envMap
+		containerDetails[types.ENVIRONMENT] = envMap
 	}
 
 	// Update session of network_mode
-	if serviceName != NETWORK_PROXY {
+	if serviceName != types.INFRA_CONTAINER {
 		if network_mode, ok := containerDetails[types.NETWORK_MODE].(string); !ok ||
 			(network_mode != types.HOST_MODE && network_mode != types.NONE_NETWORK_MODE) {
 
-			containerDetails[types.NETWORK_MODE] = "service:" + NETWORK_PROXY
+			containerDetails[types.NETWORK_MODE] = "service:" + types.INFRA_CONTAINER
 
 		} else {
 			config.GetConfig().SetDefault(types.RM_INFRA_CONTAINER, true)
@@ -129,23 +129,7 @@ func UpdateServiceSessions(serviceName, file, executorId, taskId string, filesMa
 	if containerName, ok := containerDetails[types.CONTAINER_NAME].(string); ok {
 		containerName = utils.PrefixTaskId(taskId, containerName)
 		containerDetails[types.CONTAINER_NAME] = containerName
-
-		if serviceName == NETWORK_PROXY {
-			config.SetConfig(types.INFRA_CONTAINER_NAME, containerName)
-		}
-
-		if pod.ServiceNameMap[serviceName] == "" {
-			pod.ServiceNameMap[serviceName] = containerName
-		}
-
 		logger.Println("Edit Compose File : Updated container_name as ", containerName)
-	} else {
-
-		if pod.ServiceNameMap[serviceName] == "" {
-			pod.ServiceNameMap[serviceName] = fmt.Sprintf("%s_%s",
-				strings.Replace(strings.Replace(config.GetConfig().GetString(config.FOLDER_NAME), "_", "", -1),
-					"-", "", -1), serviceName)
-		}
 	}
 
 	// Update value of LINKS
@@ -218,8 +202,7 @@ func UpdateServiceSessions(serviceName, file, executorId, taskId string, filesMa
 	}
 
 	// Add service ports to infra container
-	if serviceName == NETWORK_PROXY {
-
+	if serviceName == types.INFRA_CONTAINER {
 		if portList := config.GetConfig().Get(types.PORTS); portList != nil {
 
 			logger.Println("Add services ports mapping to infra container ", portList)

--- a/plugin/general/impl.go
+++ b/plugin/general/impl.go
@@ -15,22 +15,22 @@
 package general
 
 import (
+	"context"
 	"os"
 	"strconv"
 	"strings"
 
-	"context"
-
 	"github.com/mesos/mesos-go/executor"
 	mesos "github.com/mesos/mesos-go/mesosproto"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/plugin"
 	"github.com/paypal/dce-go/types"
 	utils "github.com/paypal/dce-go/utils/file"
 	"github.com/paypal/dce-go/utils/pod"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 var logger *log.Entry

--- a/plugin/general/impl.go
+++ b/plugin/general/impl.go
@@ -76,6 +76,7 @@ func (ge *generalExt) PreLaunchTask(ctx *context.Context, composeFiles *[]string
 
 	currentPort := pod.GetPorts(taskInfo)
 
+	// Create infra container yml file
 	infrayml, err := CreateInfraContainer(ctx, types.INFRA_CONTAINER_YML)
 	if err != nil {
 		logger.Errorln("Error creating infra container : ", err.Error())
@@ -103,8 +104,9 @@ func (ge *generalExt) PreLaunchTask(ctx *context.Context, composeFiles *[]string
 		}
 	}
 
+	// Remove infra container yml file if network mode is host
 	if config.GetConfig().GetBool(types.RM_INFRA_CONTAINER) {
-		logger.Println("Reomve infra container")
+		logger.Printf("Remove file: %s\n", types.INFRA_CONTAINER_GEN_YML)
 		filesMap := (*ctx).Value(types.SERVICE_DETAIL).(types.ServiceDetail)
 		delete(filesMap, editedFiles[indexInfra])
 		*ctx = context.WithValue(*ctx, types.SERVICE_DETAIL, filesMap)
@@ -214,7 +216,7 @@ func CreateInfraContainer(ctx *context.Context, path string) (string, error) {
 		}
 	}
 
-	service[NETWORK_PROXY] = containerDetail
+	service[types.INFRA_CONTAINER] = containerDetail
 	_yaml[types.SERVICES] = service
 	_yaml[types.VERSION] = "2.1"
 	log.Println(_yaml)

--- a/types/types.go
+++ b/types/types.go
@@ -38,6 +38,7 @@ const (
 	LINKS                   = "links"
 	PORTS                   = "ports"
 	LABELS                  = "labels"
+	ENVIRONMENT             = "environment"
 	RESTART                 = "restart"
 	SERVICES                = "services"
 	IMAGE                   = "image"
@@ -48,7 +49,6 @@ const (
 	CGROUP_PARENT           = "cgroup_parent"
 	PLUGIN_ORDER            = "pluginorder"
 	INFRA_CONTAINER_YML     = "docker-infra-container.yml"
-	INFRA_CONTAINER_NAME    = "infra"
 	HOST_MODE               = "host"
 	NONE_NETWORK_MODE       = "none"
 	NAME                    = "name"
@@ -62,6 +62,7 @@ const (
 	RM_INFRA_CONTAINER      = "rm_infra_container"
 	COMPOSE_HTTP_TIMEOUT    = "COMPOSE_HTTP_TIMEOUT"
 	SERVICE_DETAIL          = "serviceDetail"
+	INFRA_CONTAINER         = "networkproxy"
 	FOREVER                 = 1<<63 - 1
 )
 

--- a/types/types.go
+++ b/types/types.go
@@ -63,6 +63,7 @@ const (
 	COMPOSE_HTTP_TIMEOUT    = "COMPOSE_HTTP_TIMEOUT"
 	SERVICE_DETAIL          = "serviceDetail"
 	INFRA_CONTAINER         = "networkproxy"
+	IS_SERVICE              = "isService"
 	FOREVER                 = 1<<63 - 1
 )
 

--- a/utils/file/file.go
+++ b/utils/file/file.go
@@ -46,6 +46,7 @@ const (
 	FILE_POSTFIX   = "-generated.yml"
 	PATH_DELIMITER = "/"
 	MAP_DELIMITER  = "="
+	TraceFolder    = "composetrace"
 )
 
 type EditorFunc func(serviceName string, taskInfo *mesos.TaskInfo, executorId string, taskId string, containerDetails map[interface{}]interface{}, ports *list.Element) (map[interface{}]interface{}, *list.Element, error)
@@ -167,7 +168,7 @@ func IsSubset(first, second []string) bool {
 // check if file exist
 func CheckFileExist(file string) bool {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		log.Println("File does not exit")
+		log.Printf("File %s does not exist", file)
 		return false
 	}
 	return true
@@ -187,6 +188,7 @@ func WriteToFile(file string, data []byte) (string, error) {
 		file = FolderPath(strings.Fields(file))[0]
 	}
 
+	log.Printf("Write to file : %s\n", file)
 	f, err := os.Create(file)
 	if err != nil {
 		log.Errorf("Error creating file %v", err)
@@ -220,7 +222,25 @@ func WriteChangeToFiles(ctx context.Context) error {
 	return nil
 }
 
+func DumpPluginModifiedComposeFiles(ctx context.Context, plugin string, pluginOrder int) {
+	filesMap := ctx.Value(types.SERVICE_DETAIL).(types.ServiceDetail)
+	for file := range filesMap {
+		content, _ := yaml.Marshal(filesMap[file])
+		fParts := strings.Split(file.(string), PATH_DELIMITER)
+		if len(fParts) < 2 {
+			log.Printf("Skip dumping modified compose file by plugin %s, since file name is invalid %s", plugin, file)
+			return
+		}
+		_, err := WriteToFile(fmt.Sprintf("%s/%s/%s-%s-%d.yml", fParts[0], TraceFolder, fParts[1], plugin, pluginOrder), content)
+		if err != nil {
+			log.Printf("Failed dumping modified compose file by plugin %s", plugin)
+		}
+	}
+}
+
 func OverwriteFile(file string, data []byte) {
+	log.Printf("Over-write file: %s\n", file)
+
 	os.Remove(file)
 
 	f, err := os.Create(file)
@@ -236,8 +256,15 @@ func OverwriteFile(file string, data []byte) {
 
 //Split a large file into a number of smaller files by file separator
 func SplitYAML(file string) ([]string, error) {
+	logger := log.WithFields(log.Fields{
+		"File": file,
+		"Func": "SplitYAML",
+	})
+
+	logger.Println("Start split downloaded compose file")
 	var names []string
 	if _, err := os.Stat(file); os.IsNotExist(err) {
+		logger.Printf("%s doesn't exit\n", file)
 		return nil, err
 	}
 
@@ -250,20 +277,29 @@ func SplitYAML(file string) ([]string, error) {
 	scanner.Split(SplitFunc)
 	for scanner.Scan() {
 		splitData := scanner.Text()
+		logger.Printf("Split data : %s\n", splitData)
+
+		// Get split compose file name from split data
+		// If name isn't found, skip writing split data into a separate file
 		name := strings.TrimLeft(getYAMLDocumentName(splitData, "#.*yml"), "#")
 		if name == "" {
+			logger.Println("No file name found from split data")
 			continue
 		}
 		fileName, err := WriteToFile(name, []byte(splitData))
 		if err != nil {
+			logger.Errorf("Error writing files %s : %v\n", fileName, err)
 			return nil, err
 		}
 		names = append(names, fileName)
 	}
 
+	// If file doesn't need to be split, just return the file
 	if len(names) == 0 {
 		names = append(names, file)
 	}
+
+	logger.Printf("After split file, get file names: %s\n", names)
 	return FolderPath(names), nil
 }
 
@@ -311,8 +347,8 @@ func getYAMLDocumentName(data, pattern string) string {
 //ReplaceElement does replace element in array/map
 func ReplaceElement(i interface{}, old string, new string) interface{} {
 	if array, ok := i.([]interface{}); ok {
-		index, err := IndexArray(array, old)
-		if err != nil {
+		index, err := IndexArrayRegex(array, old)
+		if err != nil || index == -1 {
 			return array
 		}
 		array[index] = new
@@ -335,10 +371,12 @@ func ReplaceElement(i interface{}, old string, new string) interface{} {
 }
 
 //AppendElement does append element in array/map
+//Element will be overwrite if it already exist
+//Using regular expression to match the element
 func AppendElement(i interface{}, old string, new string) interface{} {
 	if array, ok := i.([]interface{}); ok {
-		index, err := IndexArray(array, old)
-		if err != nil {
+		index, err := IndexArrayRegex(array, old)
+		if err != nil || index == -1 {
 			array = append(array, new)
 			return array
 		} else {
@@ -356,6 +394,20 @@ func AppendElement(i interface{}, old string, new string) interface{} {
 	log.Println("Only support appending elements in array and map")
 
 	return i
+}
+
+func IndexArrayRegex(array []interface{}, expr string) (int, error) {
+	r, err := regexp.Compile(expr)
+	if err != nil {
+		log.Errorf("Error compile expression: %v\n", err)
+		return -1, err
+	}
+	for i, a := range array {
+		if r.MatchString(a.(string)) {
+			return i, nil
+		}
+	}
+	return -1, err
 }
 
 // get index of an element in array
@@ -443,25 +495,26 @@ func ParseYamls(files *[]string) (map[interface{}](map[interface{}]interface{}),
 	return res, nil
 }
 
-// app folder is used to keep all the generated yml files
+// GenerateAppFolder does generate app folder and copy compose files exist in fileName label
+// into folder
 func GenerateAppFolder() error {
-	// if app comes with a folder, then skip creating app folder
-	/*if config.GetConfig().GetBool(types.NO_FOLDER) {
-		return nil
-	}*/
-
 	folder := config.GetAppFolder()
 	if folder == "" {
 		folder = types.DEFAULT_FOLDER
 		config.SetConfig(config.FOLDER_NAME, types.DEFAULT_FOLDER)
 	}
 
+	// Append run id to folder name
 	path, _ := filepath.Abs("")
 	dirs := strings.Split(path, PATH_DELIMITER)
 	folder = strings.TrimSpace(fmt.Sprintf("%s_%s", folder, dirs[len(dirs)-1]))
 
-	_folder := []string{strings.TrimSpace(folder)}
-	err := GenerateFileDirs(_folder)
+	// Folder to keep all compose files generated by plugins
+	traceFolder := fmt.Sprintf("%s/%s", folder, TraceFolder)
+
+	// Generate directory
+	folders := []string{strings.TrimSpace(folder), traceFolder}
+	err := GenerateFileDirs(folders)
 	if err != nil {
 		log.Println("Error generating file dirs: ", err.Error())
 		return err
@@ -469,27 +522,18 @@ func GenerateAppFolder() error {
 
 	config.GetConfig().Set(config.FOLDER_NAME, folder)
 
-	// copy tar folder to poddata folder
-	/*tar := config.GetConfig().GetString(TAR)
-	if tar != "" {
-		err = CopyDir(path+"/"+tar, path+"/"+folder)
-		if err != nil {
-			log.Errorf("Failed copying directory: %v", err)
-			return err
-		}
-	}*/
-
-	// copy compose files into pod folder
+	// Copy compose files into pod folder
 	for i, file := range pod.ComposeFiles {
 		path := strings.Split(file, PATH_DELIMITER)
 		dest := FolderPath(strings.Fields(path[len(path)-1]))[0]
 		err = CopyFile(file, dest)
 		if err != nil {
-			log.Errorf("Failed to copy file into pod folder %v", err)
-			return err
+			log.Printf("Copy file %s into pod folder %v", file, err)
 		}
 		pod.ComposeFiles[i] = dest
 	}
+
+	log.Printf("compose file list: %s\n", pod.ComposeFiles)
 	return nil
 }
 
@@ -558,8 +602,22 @@ func CopyFile(source string, dest string) (err error) {
 		if err != nil {
 			err = os.Chmod(dest, sourceinfo.Mode())
 		}
-
+		log.Printf("Copy file from %s to %s\n", sourcefile.Name(), destfile.Name())
 	}
 
 	return
+}
+
+// Convert array like a=b to map a:b
+func ConvertArrayToMap(arr []interface{}) map[interface{}]interface{} {
+	m := make(map[interface{}]interface{})
+	for _, i := range arr {
+		b := strings.SplitN(i.(string), "=", 2)
+		if len(b) == 2 {
+			m[b[0]] = b[1]
+		} else {
+			m[b[0]] = ""
+		}
+	}
+	return m
 }

--- a/utils/file/file.go
+++ b/utils/file/file.go
@@ -18,7 +18,9 @@ import (
 	"bufio"
 	"bytes"
 	"container/list"
+	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -26,15 +28,10 @@ import (
 	"regexp"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
-
-	log "github.com/sirupsen/logrus"
-
-	"fmt"
-
-	"context"
-
 	mesos "github.com/mesos/mesos-go/mesosproto"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/types"
 	"github.com/paypal/dce-go/utils/pod"

--- a/utils/file/file_test.go
+++ b/utils/file/file_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mesos/mesos-go/examples/Godeps/_workspace/src/github.com/stretchr/testify/assert"
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/types"
 )
@@ -106,19 +107,38 @@ func TestReplaceArrayElement(t *testing.T) {
 	if len(res1) != len(res) {
 		t.Fatalf("Expected array doesn't change, but got %v \n", res1)
 	}
+
+	array[0] = "fruit=banana"
+	res2 := ReplaceElement(array, "^fruit=", "fruit=apple").([]interface{})
+	if res2[0] != "fruit=apple" {
+		t.Fatalf("Expected fruit=apple replace fruit=banana, but got %v \n", res2)
+	}
+
+	array[0] = "fruit.banana"
+	res5 := ReplaceElement(array, "^fruit$", "fruit=apple").([]interface{})
+	if res5[0] != "fruit.banana" {
+		t.Fatalf("Expected no changes, but got %v \n", res5)
+	}
+
+	array[0] = "fruitbanana"
+	res6 := ReplaceElement(array, "^fruit$", "fruit=apple").([]interface{})
+	if res6[0] != "fruitbanana" {
+		t.Fatalf("Expected no changes, but got %v \n", res6)
+	}
+
 	//Test map
 	m := make(map[interface{}]interface{})
 	m["key1"] = "val1"
 	m["key2"] = "val2"
-	res2 := ReplaceElement(m, "key2", "val3").(map[interface{}]interface{})
-	if res2["key2"].(string) != "val3" {
-		t.Fatalf("expected first element to be 'val3', but got %s", res2["key3"])
+	res3 := ReplaceElement(m, "key2", "val3").(map[interface{}]interface{})
+	if res3["key2"].(string) != "val3" {
+		t.Fatalf("expected first element to be 'val3', but got %s", res3["key3"])
 	}
 
-	res3 := ReplaceElement(m, "key3", "val3").(map[interface{}]interface{})
-	_, ok := res3["key3"]
+	res4 := ReplaceElement(m, "key3", "val3").(map[interface{}]interface{})
+	_, ok := res4["key3"]
 	if ok {
-		t.Fatalf("expected new element not added, but got", res2["key3"])
+		t.Fatalf("Expected new element not added, but got %s", res4["key3"])
 	}
 }
 
@@ -132,10 +152,23 @@ func TestAppendElement(t *testing.T) {
 	if len(res) != len(array)+1 || res[3] != "monkey" {
 		t.Fatalf("expected first element to be 'monkey', but got %s", res[3])
 	}
+
 	//Test duplicate element won't be appended
 	res = AppendElement(array, "monkey", "monkey").([]interface{})
 	if len(res) != len(array)+1 || res[3] != "monkey" {
 		t.Fatalf("expected first element to be 'monkey', but got %s", res[3])
+	}
+
+	array[0] = "fruit=banana"
+	res2 := AppendElement(array, "^fruit=", "fruit=apple").([]interface{})
+	if res2[0] != "fruit=apple" {
+		t.Fatalf("Expected fruit=apple replace fruit=banana, but got %v \n", res2)
+	}
+
+	array[0] = "fruit.banana"
+	res5 := AppendElement(array, "^fruit$", "fruit=apple1").([]interface{})
+	if res5[len(res5)-1] != "fruit=apple1" {
+		t.Fatalf("Expected fruit=apple will be appended, but got %v \n", res5)
 	}
 
 	//Test map
@@ -176,4 +209,16 @@ func TestSplitYAML(t *testing.T) {
 		t.Errorf("expected file name is testdata/docker-adhoc.yml , but got %v", files[0])
 	}
 	os.Remove(types.DEFAULT_FOLDER)
+}
+
+func TestConvertArrayToMap(t *testing.T) {
+	a := []interface{}{"a=b", "c", "d="}
+	m := ConvertArrayToMap(a)
+	assert.Equal(t, m["a"], "b", "a=b")
+	assert.Equal(t, m["c"], "", "c")
+	assert.Equal(t, m["d"], "", "d=")
+
+	b := []interface{}{}
+	m = ConvertArrayToMap(b)
+	assert.Equal(t, len(m), 0, "empty map")
 }

--- a/utils/http/http.go
+++ b/utils/http/http.go
@@ -32,7 +32,7 @@ func GenBody(t interface{}) io.Reader {
 	if err != nil {
 		log.Panic("Error marshalling : ", err.Error())
 	}
-	fmt.Println("Allocate IP Request Body : ", string(tjson))
+	fmt.Println("Request Body : ", string(tjson))
 	return bytes.NewReader(tjson)
 }
 

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -17,25 +17,23 @@ package pod
 import (
 	"bufio"
 	"container/list"
+	"context"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
 
-	"fmt"
-
-	"io/ioutil"
-
-	"context"
-
 	"github.com/mesos/mesos-go/executor"
 	mesos "github.com/mesos/mesos-go/mesosproto"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/types"
 	utils "github.com/paypal/dce-go/utils/wait"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/utils/pod/testdata/docker-long.yml
+++ b/utils/pod/testdata/docker-long.yml
@@ -2,3 +2,4 @@ version: "2.1"
 services:
   redis:
     image: redis
+    container_name: redis_test

--- a/utils/wait/wait.go
+++ b/utils/wait/wait.go
@@ -16,15 +16,12 @@ package wait
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	"os/exec"
-
-	"os"
-
-	"strings"
 
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/types"

--- a/utils/wait/wait.go
+++ b/utils/wait/wait.go
@@ -50,7 +50,7 @@ func PollRetry(retry int, interval time.Duration, condition ConditionFunc) error
 	log.Println("PullRetry : interval:", interval)
 
 	var err error
-	factor := 2
+	factor := 1
 	for i := 0; i < retry; i++ {
 		if i != 0 {
 			log.Println("Condition Func failed, Start Retrying : ", i)
@@ -151,7 +151,10 @@ func RetryCmd(retry int, cmd *exec.Cmd) ([]byte, error) {
 	var err error
 	var out []byte
 
+	log.Debugf("Run cmd: %s\n", cmd.Args)
+
 	retryInterval := config.GetRetryInterval()
+	factor := 1
 	for i := 0; i < retry; i++ {
 		_cmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
 
@@ -169,7 +172,7 @@ func RetryCmd(retry int, cmd *exec.Cmd) ([]byte, error) {
 			if strings.Contains(err.Error(), "already started") {
 				return out, nil
 			}
-			time.Sleep(retryInterval * time.Millisecond)
+			time.Sleep(retryInterval * time.Duration((i+1)*factor) * time.Millisecond)
 			continue
 		}
 
@@ -178,7 +181,7 @@ func RetryCmd(retry int, cmd *exec.Cmd) ([]byte, error) {
 	return nil, err
 }
 
-// Retry command util reach the maximum try out count
+// Retry command forever
 func RetryCmdLogs(cmd *exec.Cmd) ([]byte, error) {
 	var err error
 	var out []byte


### PR DESCRIPTION
1. optimize init health check 
Checking if service in the pod is running using cmd docker-compose -f [file] ps -q [service]
2. optimize pod monitor
Pod monitor will send finish to mesos if only infra container is running.
3. Add plugin tracing
Add a folder composetrace to keep all the compose files modified by each plugin.
It will be easy for debugging and figure out what does each plugin do.
4. Add signal driven debug mode.
Debug mode will be enable or disable by sending SIGUSR1 to dce process using cmd kill -SIGUSR1 [dce process id]

sandbox: http://10.180.72.46:5050/#/agents/05a9364a-0182-421a-8303-1c7c6858d32d-S64/browse?path=%2Fvar%2Flib%2Fmesos%2Fslaves%2F05a9364a-0182-421a-8303-1c7c6858d32d-S64%2Fframeworks%2Fbe208cac-365d-44da-88fb-9ac025dc96b8-0000%2Fexecutors%2Fcompose-pod-compose-test-0-e7b46f70-4731-4824-9ab2-792cdb175074%2Fruns%2Fac76330a-ba19-4789-8912-83619960af31