### PR TITLE
override config by passing mesos labels

### DIFF
--- a/dce/main.go
+++ b/dce/main.go
@@ -111,6 +111,9 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 		logger.Errorln("Error creating app folder")
 	}
 
+	// Override config
+	config.OverrideConfig(taskInfo)
+
 	// Create context with timeout
 	// Wait for pod launching until timeout
 	var ctx context.Context


### PR DESCRIPTION
Support config override by passing labels to mesos with prefix "config."

For example, you can add "config.launchtask.timeout" with any value in labels to override  default timeout.