### PR TITLE
support any compose file version between 2.1 to 3.0

### DIFF
--- a/plugin/general/editor.go
+++ b/plugin/general/editor.go
@@ -61,7 +61,8 @@ func editComposeFile(ctx *context.Context, file string, executorId string, taskI
 		}
 	}
 
-	filesMap[file][types.VERSION] = "2.1"
+	filesMap[file][types.VERSION] = getVersion(filesMap, file)
+
 	if !strings.Contains(file, utils.FILE_POSTFIX) {
 		filesMap[file+utils.FILE_POSTFIX] = filesMap[file]
 		delete(filesMap, file)
@@ -71,6 +72,20 @@ func editComposeFile(ctx *context.Context, file string, executorId string, taskI
 
 	logger.Printf("Updated compose files, current context: %v\n", filesMap)
 	return file, ports, err
+}
+
+func getVersion(filesMap types.ServiceDetail, file string) string {
+	if currentVersion, ok := filesMap[file][types.VERSION].(string); ok {
+		currentVersionFloat, err := strconv.ParseFloat(currentVersion, 64)
+		if err != nil {
+			log.Printf("Error trying to change version from str to float. Defaulting it to 2.1")
+		} else {
+			if currentVersionFloat > 2.1 && currentVersionFloat < 3.0 {
+				return fmt.Sprintf("%.1f", currentVersionFloat)
+			}
+		}
+	}
+	return "2.1"
 }
 
 func updateServiceSessions(serviceName, file, executorId, taskId string, filesMap types.ServiceDetail, ports *list.Element,

--- a/plugin/general/editor.go
+++ b/plugin/general/editor.go
@@ -31,10 +31,11 @@ import (
 )
 
 const (
-	PORT_DELIMITER = ":"
-	PATH_DELIMITER = "/"
-	TASK_ID        = "taskId"
-	EXECUTOR_ID    = "executorId"
+	PORT_DELIMITER  = ":"
+	PATH_DELIMITER  = "/"
+	TASK_ID         = "taskId"
+	EXECUTOR_ID     = "executorId"
+	DEFAULT_VERSION = "2.1"
 )
 
 func editComposeFile(ctx *context.Context, file string, executorId string, taskId string, ports *list.Element,
@@ -75,17 +76,21 @@ func editComposeFile(ctx *context.Context, file string, executorId string, taskI
 }
 
 func getVersion(filesMap types.ServiceDetail, file string) string {
-	if currentVersion, ok := filesMap[file][types.VERSION].(string); ok {
-		currentVersionFloat, err := strconv.ParseFloat(currentVersion, 64)
-		if err != nil {
-			log.Errorf("Error trying to change version from str to float. Defaulting it to 2.1")
-			return "2.1"
-		}
-		if currentVersionFloat > 2.1 && currentVersionFloat < 3.0 {
-			return fmt.Sprintf("%.1f", currentVersionFloat)
-		}
+	currentVersion, ok := filesMap[file][types.VERSION].(string)
+	if !ok {
+		log.Errorf("Error find version or cast version to string. Defaulting it to %s", DEFAULT_VERSION)
+		return DEFAULT_VERSION
 	}
-	return "2.1"
+	currentVersionFloat, err := strconv.ParseFloat(currentVersion, 64)
+	if err != nil {
+		log.Errorf("Error trying to change version from str to float. Defaulting it to %s", DEFAULT_VERSION)
+		return DEFAULT_VERSION
+	}
+	if currentVersionFloat > 2.1 && currentVersionFloat < 3.0 {
+		return fmt.Sprintf("%.1f", currentVersionFloat)
+	}
+
+	return DEFAULT_VERSION
 }
 
 func updateServiceSessions(serviceName, file, executorId, taskId string, filesMap types.ServiceDetail, ports *list.Element,

--- a/plugin/general/editor.go
+++ b/plugin/general/editor.go
@@ -78,11 +78,11 @@ func getVersion(filesMap types.ServiceDetail, file string) string {
 	if currentVersion, ok := filesMap[file][types.VERSION].(string); ok {
 		currentVersionFloat, err := strconv.ParseFloat(currentVersion, 64)
 		if err != nil {
-			log.Printf("Error trying to change version from str to float. Defaulting it to 2.1")
-		} else {
-			if currentVersionFloat > 2.1 && currentVersionFloat < 3.0 {
-				return fmt.Sprintf("%.1f", currentVersionFloat)
-			}
+			log.Errorf("Error trying to change version from str to float. Defaulting it to 2.1")
+			return "2.1"
+		}
+		if currentVersionFloat > 2.1 && currentVersionFloat < 3.0 {
+			return fmt.Sprintf("%.1f", currentVersionFloat)
 		}
 	}
 	return "2.1"

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -814,7 +814,7 @@ func SendMesosStatus(driver executor.ExecutorDriver, taskId *mesos.TaskID, state
 			state.Enum().String() == mesos.TaskState_TASK_FAILED.Enum().String() {
 
 			log.Printf("Calling log write function again for container logs.")
-			dockerLogToPodLogFile(ComposeFiles, false)
+			go dockerLogToPodLogFile(ComposeFiles, false)
 		}
 	}
 


### PR DESCRIPTION
This PR has one bug fix and one compose file version enhancement.

Enhancement: support any compose file version between 2.1 to 3.0. (Note: 3.0 is excluded.)
Fix: To avoid executor leaks caused by docker log command hang, have docker log command in a goroutine. 