### PR TITLE
Compose validation 

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -30,6 +30,7 @@ const (
 	POD_KILLED
 	POD_FINISHED
 	POD_PULL_FAILED
+	POD_COMPOSE_CHECK_FAILED
 	POD_EMPTY
 )
 
@@ -49,6 +50,8 @@ func (status PodStatus) String() string {
 		return "POD_FINISHED"
 	case POD_PULL_FAILED:
 		return "POD_PULL_FAILED"
+	case POD_COMPOSE_CHECK_FAILED:
+		return "POD_COMPOSE_CHECK_FAILED"
 	case POD_EMPTY:
 		return ""
 	}
@@ -89,6 +92,7 @@ const (
 	LABELS                  = "labels"
 	ENVIRONMENT             = "environment"
 	RESTART                 = "restart"
+	APP_START_TIME          = "appStartTime"
 	SERVICES                = "services"
 	IMAGE                   = "image"
 	VERSION                 = "version"

--- a/utils/util.go
+++ b/utils/util.go
@@ -41,6 +41,8 @@ func ToPodStatus(s string) types.PodStatus {
 		return types.POD_FINISHED
 	case "POD_PULL_FAILED":
 		return types.POD_PULL_FAILED
+	case "POD_COMPOSE_CHECK_FAILED":
+		return types.POD_COMPOSE_CHECK_FAILED
 	}
 
 	return types.POD_EMPTY


### PR DESCRIPTION
1. Added validation for docker-compose before we pull the image.
Command: docker-compose  -f docker-compose-base.yml-generated.yml -f docker-compose-qa.yml-generated.yml config
If it fails logs will contain POD_BAD_MANIFEST_FAILURE and POD Status will be updated as POD_COMPOSE_CHECK_FAILED
2. Added app launch time to context with key "appStartTime" the value is a Time.time object.
3. A log has been added to show the time lapsed since app launch till after image pull.
Log: "Time elapsed since App launch: 10s"
4. Rearranged code to retry logging logs after mesos status has been sent.

Bad Manifest validation fail: http://10.180.72.17:5050/#/agents/dfbf06ff-5602-4028-865b-1fec8918ab9a-S54/browse?path=%2Fx%2Fhome%2Fmesos%2Fslaves%2Fdfbf06ff-5602-4028-865b-1fec8918ab9a-S54%2Fframeworks%2Fbe208cac-365d-44da-88fb-9ac025dc96b8-0000%2Fexecutors%2Fcompose-paypal-dockerserv18121716773475-dockerserv-a-0-19366c9e-9533-46db-9774-f8ebeb195c0e%2Fruns%2F062f4ac9-695a-483b-8908-6621520efdf6

Working example: http://10.180.72.17:5050/#/agents/a15a0103-e43b-4ec7-b63d-5af02cb5adf8-S0/browse?path=%2Fx%2Fhome%2Fmesos%2Fslaves%2Fa15a0103-e43b-4ec7-b63d-5af02cb5adf8-S0%2Fframeworks%2Fbe208cac-365d-44da-88fb-9ac025dc96b8-0000%2Fexecutors%2Fcompose-paypal-dockerserv18121716773475-dockerserv-a-0-fc7d9eeb-c544-4f94-95e7-e2eb50cf2024%2Fruns%2Fba52eba4-835f-4d48-be26-ca56a21fb2d0
