### PR TITLE
stop driver on any status when receive mesos kill

### DIFF
--- a/dce/main.go
+++ b/dce/main.go
@@ -295,6 +295,12 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 func (exec *dockerComposeExecutor) KillTask(driver exec.ExecutorDriver, taskId *mesos.TaskID) {
 	log.Println("====================Mesos KillTask====================")
 
+	defer func() {
+		log.Println("====================Stop ExecutorDriver====================")
+		time.Sleep(5 * time.Second)
+		driver.Stop()
+	}()
+
 	logKill := log.WithFields(log.Fields{
 		"taskId": taskId,
 	})
@@ -318,9 +324,8 @@ func (exec *dockerComposeExecutor) KillTask(driver exec.ExecutorDriver, taskId *
 			logKill.Errorf("Error during kill Task : %v", err.Error())
 		}
 
-		log.Println("====================Stop ExecutorDriver====================")
-		time.Sleep(200 * time.Millisecond)
-		driver.Stop()
+	default:
+		log.Infof("current pod status %s, stop driver", status)
 
 	}
 

--- a/dce/monitor/monitor.go
+++ b/dce/monitor/monitor.go
@@ -62,6 +62,10 @@ func podMonitor(systemProxyId string) types.PodStatus {
 		}
 
 		if healthy == types.UNHEALTHY {
+			err = pod.PrintInspectDetail(pod.MonitorContainerList[i])
+			if err != nil {
+				log.Warnf("Error during docker inspect: ", err)
+			}
 			if config.GetConfigSection(config.CLEANPOD) == nil ||
 				config.GetConfigSection(config.CLEANPOD)[types.UNHEALTHY.String()] == "true" {
 				logger.Println("POD_MONITOR_HEALTH_CHECK_FAILED -- Stop pod monitor and send Failed")

--- a/plugin/general/impl.go
+++ b/plugin/general/impl.go
@@ -175,7 +175,7 @@ func (gp *generalExt) PostKillTask(taskInfo *mesos.TaskInfo) error {
 		return nil
 	}
 
-	if pod.GetPodStatus() != types.POD_FAILED || (pod.GetPodStatus() == types.POD_FAILED && config.GetConfig().GetBool(config.CLEAN_FAIL_TASK)) {
+	if pod.GetPodStatus() != types.POD_FAILED || config.GetConfig().GetBool(config.CLEAN_FAIL_TASK) {
 		// clean pod volume and container if clean_container_volume_on_kill is true
 		cleanVolumeAndContainer := config.GetConfig().GetBool(config.CLEAN_CONTAINER_VOLUME_ON_MESOS_KILL)
 		if cleanVolumeAndContainer {


### PR DESCRIPTION
1. driver should always be stopped to avoid DCE leaks once receive mesos kill
2. print result of docker inspect on fail container if init health check failed or monitor failed