### PR TITLE
Fixed extra hosts not populating in infra container

### DIFF
--- a/pluginimpl/general/editor.go
+++ b/pluginimpl/general/editor.go
@@ -199,7 +199,7 @@ func updateServiceSessions(serviceName, file, executorId, taskId string, filesMa
 					portMap := strings.Split(p.(string), PORT_DELIMITER)
 					if len(portMap) > 1 {
 						if ports == nil {
-							return nil, errors.New("No ports available")
+							return nil, errors.New("no ports available")
 						}
 						p = strconv.FormatUint(ports.Value.(uint64), 10) + PORT_DELIMITER + portMap[1]
 						portList[i] = p.(string)
@@ -316,22 +316,19 @@ func addExtraHostsSection(ctx *context.Context, file, svcName string, extraHosts
 		return
 	}
 
-	if containerDetails, ok := servMap[svcName].(map[interface{}]interface{}); ok {
-		// i.e. only if some new extra_hosts were found in the compose files other than the ones already defined in infra container yaml
-		if val, ok := containerDetails[types.EXTRA_HOSTS].([]interface{}); ok {
-			for _, v := range val {
-				extraHostsCollection[v] = true
-			}
-
-			var extraHostsList []interface{}
-			for key := range extraHostsCollection {
-				extraHostsList = append(extraHostsList, key)
-			}
-			containerDetails[types.EXTRA_HOSTS] = extraHostsList
-			filesMap[file][types.SERVICES].(map[interface{}]interface{})[svcName] = containerDetails
-			logger.Printf("Added extra_hosts section to the file %s under service %s", file, svcName)
-		}
+	containerDetails, ok := servMap[svcName].(map[interface{}]interface{})
+	if !ok {
+		log.Warnf("Couldn't get service details from compose file %s", file)
 		return
-
+	}
+	// add extra hosts if available
+	if len(extraHostsCollection) != 0 {
+		var extraHostsList []interface{}
+		for key := range extraHostsCollection {
+			extraHostsList = append(extraHostsList, key)
+		}
+		containerDetails[types.EXTRA_HOSTS] = extraHostsList
+		logger.Printf("Added extra_hosts section to the file %s under service %s", file, svcName)
+		filesMap[file][types.SERVICES].(map[interface{}]interface{})[svcName] = containerDetails
 	}
 }

--- a/pluginimpl/general/impl_test.go
+++ b/pluginimpl/general/impl_test.go
@@ -28,8 +28,7 @@ import (
 
 func TestCreateInfraContainer(t *testing.T) {
 	config.GetConfig().SetDefault(types.NO_FOLDER, true)
-	var ctx context.Context
-	ctx = context.Background()
+	ctx := context.Background()
 	_, err := CreateInfraContainer(&ctx, "testdata/docker-infra-container.yml")
 	if err != nil {
 		t.Errorf("expected no error, but got %v", err)
@@ -39,8 +38,7 @@ func TestCreateInfraContainer(t *testing.T) {
 func TestGeneralExt_LaunchTaskPreImagePull(t *testing.T) {
 	config.GetConfig().SetDefault(types.NO_FOLDER, true)
 	g := new(generalExt)
-	var ctx context.Context
-	ctx = context.Background()
+	ctx := context.Background()
 	begin, _ := strconv.ParseUint("1000", 10, 64)
 	end, _ := strconv.ParseUint("1003", 10, 64)
 	r := []*mesosproto.Value_Range{


### PR DESCRIPTION
**Background**:
Docker-compose supports extra hosts for adding hosts to container.[Docker-Compose-Spec](https://docs.docker.com/compose/compose-file/#extra_hosts)
Entries defined under extra hosts in docker-compose are  added in `/etc/hosts`. 

---
**What this bug fixes:**
Prior to this fix if extra_hosts defined in manifest  after file split dce was not adding extra_hosts section in compose files. 
This fix propagates extra_hosts from original manifest to auto generated manifest file so that container should have correct entries in `/etc/hosts`