### PR TITLE
fix bug on status update

### DIFF
--- a/dce/main.go
+++ b/dce/main.go
@@ -269,8 +269,8 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 		if tempStatus == types.POD_FAILED.String() {
 			cancel()
 			pod.SendPodStatus(types.POD_FAILED)
+			return
 		}
-
 		if res == types.POD_RUNNING {
 			cancel()
 			if pod.GetPodStatus() != types.POD_RUNNING {
@@ -278,7 +278,6 @@ func (exec *dockerComposeExecutor) LaunchTask(driver exec.ExecutorDriver, taskIn
 				go monitor.MonitorPoller()
 			}
 		}
-
 		//For adhoc job, send finished to mesos if job already finished during init health check
 		if res == types.POD_FINISHED {
 			cancel()

--- a/dce/monitor/monitor.go
+++ b/dce/monitor/monitor.go
@@ -136,6 +136,8 @@ func MonitorPoller() {
 	logger.Printf("Pod Monitor Receiver : Received  message %s", res)
 
 	curPodStatus := pod.GetPodStatus()
+	// Once mesos send admin kill to the pod, monitor also will find containers exist
+	// have following check to avoid sending redundant or invalid status
 	if curPodStatus == types.POD_KILLED || curPodStatus == types.POD_FAILED {
 		logger.Println("====================Pod Monitor Stopped====================")
 		return

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -823,6 +823,7 @@ func SendPodStatus(status types.PodStatus) {
 	if curntPodStatus == types.POD_FAILED || curntPodStatus == types.POD_KILLED ||
 		curntPodStatus == types.POD_FINISHED || curntPodStatus == status {
 		logger.Printf("Task has already been killed or failed or finished or updated as required status: %s", curntPodStatus)
+		return
 	}
 
 	SetPodStatus(status)
@@ -919,7 +920,6 @@ func WaitOnPod(ctx *context.Context) {
 			log.Println("POD_LAUNCH_TIMEOUT")
 			if dump, ok := config.GetConfig().GetStringMap("dockerdump")["enable"].(bool); ok && dump {
 				DockerDump()
-				
 			}
 			SendPodStatus(types.POD_FAILED)
 		} else if (*ctx).Err() == context.Canceled {
@@ -1283,7 +1283,7 @@ func execPodStatusHooks(status string, taskInfo *mesos.TaskInfo) error {
 	})
 	var podStatusHooks []string
 	if podStatusHooks = config.GetConfig().GetStringSlice(fmt.Sprintf("podStatusHooks.%s",
-		 status)); len(podStatusHooks) < 1 {
+		status)); len(podStatusHooks) < 1 {
 		logger.Infof("No post podStatusHook implementations found in config, skipping")
 		return nil
 	}


### PR DESCRIPTION
If pod is already in any terminal status, should skip status update and avoid ending invalid status to mesos.