### PR TITLE
Adding support for creating dev environment using docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dce/executor
 executor
 .gitmodules
 paypal-plugins/
+examples/sampleapp.tar.gz
+dce-go-linux-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 install:
   - go build -o dce-go-linux-amd64 dce/main.go
-  - docker-compose up
+  - docker-compose up -d
 
 script:
   - go run examples/client.go -cmd create -executor compose -url http://localhost:8081

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
   - docker-compose up -d
 
 script:
-  - sleep 5
-  - go run examples/client.go -cmd create -executor compose -url http://localhost:8081
+  - go run examples/docker-compose/create.go
+  - go run examples/docker-compose/kill.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - docker-compose up
 
 script:
-  - go run examples/client.go -cmd kill -executor compose -url http://localhost:8081
+  - go run examples/client.go -cmd create -executor compose -url http://localhost:8081

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
   - docker-compose up -d
 
 script:
+  - sleep 5
   - go run examples/client.go -cmd create -executor compose -url http://localhost:8081

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: go
 
 go:
-  - "1.13.x"
+  - "1.14.x"
+
+services:
+  - docker
+
+before_install:
+  - tar -czf examples/sampleapp.tar.gz -C examples/ sampleapp
+
+install:
+  - go build -o dce-go-linux-amd64 dce/main.go
+  - docker-compose up
 
 script:
-  - go build -o executor dce/main.go
+  - go run examples/client.go -cmd kill -executor compose -url http://localhost:8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,88 @@
+version: "2"
+
+services:
+  zk:
+    image: aurorascheduler/zookeeper
+    restart: on-failure
+    ports:
+    - "2181:2181"
+    environment:
+      ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+      ZK_ID: 1
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.2
+
+  master:
+    image: aurorascheduler/mesos-master:1.6.2
+    restart: on-failure
+    ports:
+    - "5050:5050"
+    environment:
+      MESOS_ZK: zk://192.168.33.2:2181/mesos
+      MESOS_QUORUM: 1
+      MESOS_HOSTNAME: localhost
+      MESOS_CLUSTER: test-cluster
+      MESOS_REGISTRY: replicated_log
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.3
+    depends_on:
+    - zk
+
+  agent-one:
+    image: dcego/mesos-agent:1.6.2
+    pid: host
+    restart: on-failure
+    ports:
+    - "5051:5051"
+    environment:
+      MESOS_MASTER: zk://192.168.33.2:2181/mesos
+      MESOS_CONTAINERIZERS: docker,mesos
+      MESOS_PORT: 5051
+      MESOS_HOSTNAME: localhost
+      MESOS_RESOURCES: ports(*):[11000-11999]
+      MESOS_SYSTEMD_ENABLE_SUPPORT: 'false'
+      MESOS_WORK_DIR: /tmp/mesos
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.4
+
+    volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup
+    - /var/run/docker.sock:/var/run/docker.sock
+    - ./:/dce-go
+    depends_on:
+    - zk
+
+  aurora-scheduler:
+    image: aurorascheduler/scheduler:0.22.0
+    pid: host
+    ports:
+    - "8081:8081"
+    restart: on-failure
+    environment:
+      CLUSTER_NAME: test-cluster
+      ZK_ENDPOINTS: "192.168.33.2:2181"
+      MESOS_MASTER: "zk://192.168.33.2:2181/mesos"
+      EXTRA_SCHEDULER_ARGS: >
+        -custom_executor_config=/dce-go/examples/docker-compose/docker-compose-executor.json
+        -enable_mesos_fetcher=true
+    networks:
+      aurora_cluster:
+        ipv4_address: 192.168.33.7
+    volumes:
+    - ./:/dce-go
+    depends_on:
+    - zk
+    - master
+    - agent-one
+
+networks:
+  aurora_cluster:
+    driver: bridge
+    ipam:
+      config:
+      - subnet: 192.168.33.0/16
+        gateway: 192.168.33.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,9 @@ services:
       EXTRA_SCHEDULER_ARGS: >
         -custom_executor_config=/dce-go/examples/docker-compose/docker-compose-executor.json
         -enable_mesos_fetcher=true
+        -transient_task_state_timeout=10mins
+        -min_offer_hold_time=1mins
+
     networks:
       aurora_cluster:
         ipv4_address: 192.168.33.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     - zk
 
   mesos-agent:
-    image: rdelvalle/mesos-agent-compose:1.6.2
+    image: dcego/mesos-agent:1.6.2
     pid: host
     restart: on-failure
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     - zk
 
   mesos-agent:
-    image: dcego/mesos-agent:1.6.2
+    image: rdelvalle/mesos-agent-compose:1.6.2
     pid: host
     restart: on-failure
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       aurora_cluster:
         ipv4_address: 192.168.33.2
 
-  master:
+  mesos-master:
     image: aurorascheduler/mesos-master:1.6.2
     restart: on-failure
     ports:
@@ -31,7 +31,7 @@ services:
     depends_on:
     - zk
 
-  agent-one:
+  mesos-agent:
     image: dcego/mesos-agent:1.6.2
     pid: host
     restart: on-failure
@@ -76,8 +76,8 @@ services:
     - ./:/dce-go
     depends_on:
     - zk
-    - master
-    - agent-one
+    - mesos-master
+    - mesos-agent
 
 networks:
   aurora_cluster:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -9,7 +9,7 @@ This vagrant box helps you quickly create DCE environment which has mesos, marat
 * Vagrant
 * Git
 
-### Steps
+### Vagrant Setup
 1. [Install VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 
 2. [Install Vagrant](https://www.vagrantup.com/downloads.html)
@@ -40,4 +40,40 @@ This vagrant box helps you quickly create DCE environment which has mesos, marat
   vagrant ssh
   ```
 7. Next: [How to use](how-to-use.md)
+
+### Docker-Compose Setup
+
+1. [Install docker](https://docs.docker.com/get-docker/)
+
+1. [Install docker-compose](https://docs.docker.com/compose/install/)
+
+1. Clone the git repository: `$ git clone https://github.com/paypal/dce-go`
+
+1. Build the executor: `$ GOOS=linux GOARCH=amd64 go build -o dce-go-linux-amd64 dce/main.go`
+
+1. Use docker-compose to bring up environment: `$ docker-compose up -d`
+
+The base set up is now ready. Aurora's and Mesos' Web UI should now be available.
+
+They can be found at:
+
+* Aurora: http://localhost:8081 (Mac) or http://192.168.33.7:8081 (Linux)
+* Mesos: http://localhost:5050 (Mac) or http://192.168.33.3:5050 (Linux)
+
+
+#### Running a sample job in docker-compose environment
+
+1. Create a tar.gz from our sample application:
+
+`$  tar -czf examples/sampleapp.tar.gz -C examples/ sampleapp`
+
+2. Use gorealis to create a job in Aurora:
+
+`$ go run examples/docker-compose/create.go`
+
+3. Navigate to the Aurora or Mesos UI to see progress of job creation.
+
+4. If needed, the job may now be killed using gorealis:
+
+`$ go run examples/docker-compose/kill.go`
 

--- a/docs/how-to-develop.md
+++ b/docs/how-to-develop.md
@@ -290,8 +290,9 @@ For details, please follow [sample compose manifests here](../examples/manifest)
 
 This project has makefile to build and upload binary for vagrant setup. Below following commands helps achieve this.
 ```
-   $ cd $GOPATH/src/github.com/paypal/dce-go
-   $ make build
+   $ git clone https://github.com/paypal/dce-go
+   $ cd dce-go
+   $ go build -o executor dce/main.go
 ```
 
 To upload binary file to nginx used in vagrant setup. Note that upload target is only meant for vagrant setup. 

--- a/examples/client.go
+++ b/examples/client.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/paypal/gorealis"
 	"github.com/paypal/gorealis/gen-go/apache/aurora"
-	_"github.com/paypal/gorealis/response"
+	_ "github.com/paypal/gorealis/response"
 )
 
 func main() {

--- a/examples/client.go
+++ b/examples/client.go
@@ -61,7 +61,7 @@ func main() {
 			InstanceCount(1).
 			AddPorts(4).
 			AddLabel("fileName", "sampleapp/docker-compose.yml,sampleapp/docker-compose-healthcheck.yml").
-			AddURIs(true, false, "http://192.168.33.8/app.tar.gz")
+			AddURIs(true, false, "/dce-go/examples/sampleapp.tar.gz")
 		break
 	case "none":
 		job = realis.NewJob().

--- a/examples/client.go
+++ b/examples/client.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/paypal/gorealis"
 	"github.com/paypal/gorealis/gen-go/apache/aurora"
-	_ "github.com/paypal/gorealis/response"
+	_"github.com/paypal/gorealis/response"
 )
 
 func main() {
@@ -61,7 +61,7 @@ func main() {
 			InstanceCount(1).
 			AddPorts(4).
 			AddLabel("fileName", "sampleapp/docker-compose.yml,sampleapp/docker-compose-healthcheck.yml").
-			AddURIs(true, false, "/dce-go/examples/sampleapp.tar.gz")
+			AddURIs(true, false, "http://192.168.33.8/app.tar.gz")
 		break
 	case "none":
 		job = realis.NewJob().

--- a/examples/docker-compose/MesosAgent.Dockerfile
+++ b/examples/docker-compose/MesosAgent.Dockerfile
@@ -1,0 +1,7 @@
+FROM aurorascheduler/mesos:1.6.2
+
+# Install docker-compose
+RUN curl -L "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+ENTRYPOINT ["mesos-slave"]

--- a/examples/docker-compose/config.yaml
+++ b/examples/docker-compose/config.yaml
@@ -1,0 +1,8 @@
+launchtask:
+   podmonitorinterval: 10000
+   pullretry: 3
+   maxretry: 10
+   timeout: 500000
+plugins:
+   pluginorder: general
+foldername: poddata

--- a/examples/docker-compose/create.go
+++ b/examples/docker-compose/create.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+    "fmt"
+    "os"
+
+    realis "github.com/paypal/gorealis"
+    "github.com/paypal/gorealis/gen-go/apache/aurora"
+)
+
+func main() {
+    r, err := realis.NewRealisClient(
+        realis.SchedulerUrl("localhost"),
+        realis.BasicAuth("aurora", "password"),
+        realis.ThriftJSON(),
+        realis.TimeoutMS(20000),
+        realis.Debug(),
+        )
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+    job := realis.NewJob().
+        Environment("prod").
+        Role("vagrant").
+        Name("sampleapp").
+        ExecutorName("docker-compose-executor").
+        ExecutorData("{}").
+        CPU(0.25).
+        RAM(256).
+        Disk(100).
+        IsService(true).
+        InstanceCount(1).
+        AddPorts(4).
+        AddLabel("fileName", "sampleapp/docker-compose.yml,sampleapp/docker-compose-healthcheck.yml").
+        AddURIs(true, false, "/dce-go/examples/sampleapp.tar.gz")
+
+    fmt.Printf("Creating job %v\n", job.JobKey())
+
+    resp, err := r.CreateJob(job)
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+    fmt.Println(resp.String())
+
+    monitor := &realis.Monitor{Client: r}
+    if resp.ResponseCode == aurora.ResponseCode_OK {
+        if ok, err := monitor.Instances(job.JobKey(), job.GetInstanceCount(), 5, 500); !ok || err != nil {
+            _, err := r.KillJob(job.JobKey())
+            if err != nil {
+                fmt.Println(err)
+                os.Exit(1)
+            }
+        }
+    }
+}

--- a/examples/docker-compose/create.go
+++ b/examples/docker-compose/create.go
@@ -1,57 +1,57 @@
 package main
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    realis "github.com/paypal/gorealis"
-    "github.com/paypal/gorealis/gen-go/apache/aurora"
+	realis "github.com/paypal/gorealis"
+	"github.com/paypal/gorealis/gen-go/apache/aurora"
 )
 
 func main() {
-    r, err := realis.NewRealisClient(
-        realis.SchedulerUrl("localhost"),
-        realis.BasicAuth("aurora", "password"),
-        realis.ThriftJSON(),
-        realis.TimeoutMS(20000),
-        realis.Debug(),
-        )
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
-    job := realis.NewJob().
-        Environment("prod").
-        Role("vagrant").
-        Name("sampleapp").
-        ExecutorName("docker-compose-executor").
-        ExecutorData("{}").
-        CPU(0.25).
-        RAM(256).
-        Disk(100).
-        IsService(true).
-        InstanceCount(1).
-        AddPorts(4).
-        AddLabel("fileName", "sampleapp/docker-compose.yml,sampleapp/docker-compose-healthcheck.yml").
-        AddURIs(true, false, "/dce-go/examples/sampleapp.tar.gz")
+	r, err := realis.NewRealisClient(
+		realis.SchedulerUrl("localhost"),
+		realis.BasicAuth("aurora", "password"),
+		realis.ThriftJSON(),
+		realis.TimeoutMS(20000),
+		realis.Debug(),
+	)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	job := realis.NewJob().
+		Environment("prod").
+		Role("vagrant").
+		Name("sampleapp").
+		ExecutorName("docker-compose-executor").
+		ExecutorData("{}").
+		CPU(0.25).
+		RAM(256).
+		Disk(100).
+		IsService(true).
+		InstanceCount(1).
+		AddPorts(4).
+		AddLabel("fileName", "sampleapp/docker-compose.yml,sampleapp/docker-compose-healthcheck.yml").
+		AddURIs(true, false, "/dce-go/examples/sampleapp.tar.gz")
 
-    fmt.Printf("Creating job %v\n", job.JobKey())
+	fmt.Printf("Creating job %v\n", job.JobKey())
 
-    resp, err := r.CreateJob(job)
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
-    fmt.Println(resp.String())
+	resp, err := r.CreateJob(job)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Println(resp.String())
 
-    monitor := &realis.Monitor{Client: r}
-    if resp.ResponseCode == aurora.ResponseCode_OK {
-        if ok, err := monitor.Instances(job.JobKey(), job.GetInstanceCount(), 5, 500); !ok || err != nil {
-            _, err := r.KillJob(job.JobKey())
-            if err != nil {
-                fmt.Println(err)
-                os.Exit(1)
-            }
-        }
-    }
+	monitor := &realis.Monitor{Client: r}
+	if resp.ResponseCode == aurora.ResponseCode_OK {
+		if ok, err := monitor.Instances(job.JobKey(), job.GetInstanceCount(), 5, 500); !ok || err != nil {
+			_, err := r.KillJob(job.JobKey())
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+	}
 }

--- a/examples/docker-compose/docker-compose-executor.json
+++ b/examples/docker-compose/docker-compose-executor.json
@@ -1,0 +1,48 @@
+[
+  {
+    "executor": {
+      "command": {
+        "value": "./dce-go-linux-amd64 -log_dir=/var/log -logtostderr=true -v=1",
+        "shell": "true",
+        "uris": [
+          {
+            "cache": false,
+            "executable": true,
+            "extract": false,
+            "value": "/dce-go/dce-go-linux-amd64"
+          },
+          {
+            "cache": false,
+            "executable": false,
+            "extract": false,
+            "value": "/dce-go/examples/docker-compose/config.yaml"
+          },
+          {
+            "cache": false,
+            "executable": false,
+            "extract": false,
+            "value": "/dce-go/examples/docker-compose/general.yaml"
+          }
+        ]
+      },
+      "name": "docker-compose-executor",
+      "resources": [
+        {
+          "name": "cpus",
+          "scalar": {
+            "value": 0.25
+          },
+          "type": "SCALAR"
+        },
+        {
+          "name": "mem",
+          "scalar": {
+            "value": 256
+          },
+          "type": "SCALAR"
+        }
+      ]
+    },
+    "task_prefix": "compose-"
+  }
+]

--- a/examples/docker-compose/general.yaml
+++ b/examples/docker-compose/general.yaml
@@ -1,0 +1,5 @@
+infracontainer:
+  image: dcego/networkproxy:1.2
+  container_name: networkproxy_0.1
+  networks:
+    pre_existing: false

--- a/examples/docker-compose/kill.go
+++ b/examples/docker-compose/kill.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+    "fmt"
+    "os"
+
+    realis "github.com/paypal/gorealis"
+    "github.com/paypal/gorealis/gen-go/apache/aurora"
+)
+
+func main() {
+    r, err := realis.NewRealisClient(
+        realis.SchedulerUrl("localhost"),
+        realis.BasicAuth("aurora", "password"),
+        realis.ThriftJSON(),
+        realis.TimeoutMS(20000),
+        realis.Debug(),
+    )
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+
+    job := realis.NewJob().
+        Environment("prod").
+        Role("vagrant").
+        Name("sampleapp")
+
+    fmt.Printf("Killing job %v\n", job.JobKey())
+    resp, err := r.KillJob(job.JobKey())
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+
+    monitor := &realis.Monitor{Client: r}
+    if resp.ResponseCode == aurora.ResponseCode_OK {
+        if ok, err := monitor.Instances(job.JobKey(), 0, 5, 50); !ok || err != nil {
+            fmt.Println("Unable to kill all instances of job")
+            os.Exit(1)
+        }
+    }
+    fmt.Println(resp.String())
+}

--- a/examples/docker-compose/kill.go
+++ b/examples/docker-compose/kill.go
@@ -1,44 +1,44 @@
 package main
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    realis "github.com/paypal/gorealis"
-    "github.com/paypal/gorealis/gen-go/apache/aurora"
+	realis "github.com/paypal/gorealis"
+	"github.com/paypal/gorealis/gen-go/apache/aurora"
 )
 
 func main() {
-    r, err := realis.NewRealisClient(
-        realis.SchedulerUrl("localhost"),
-        realis.BasicAuth("aurora", "password"),
-        realis.ThriftJSON(),
-        realis.TimeoutMS(20000),
-        realis.Debug(),
-    )
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	r, err := realis.NewRealisClient(
+		realis.SchedulerUrl("localhost"),
+		realis.BasicAuth("aurora", "password"),
+		realis.ThriftJSON(),
+		realis.TimeoutMS(20000),
+		realis.Debug(),
+	)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
-    job := realis.NewJob().
-        Environment("prod").
-        Role("vagrant").
-        Name("sampleapp")
+	job := realis.NewJob().
+		Environment("prod").
+		Role("vagrant").
+		Name("sampleapp")
 
-    fmt.Printf("Killing job %v\n", job.JobKey())
-    resp, err := r.KillJob(job.JobKey())
-    if err != nil {
-        fmt.Println(err)
-        os.Exit(1)
-    }
+	fmt.Printf("Killing job %v\n", job.JobKey())
+	resp, err := r.KillJob(job.JobKey())
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
-    monitor := &realis.Monitor{Client: r}
-    if resp.ResponseCode == aurora.ResponseCode_OK {
-        if ok, err := monitor.Instances(job.JobKey(), 0, 5, 50); !ok || err != nil {
-            fmt.Println("Unable to kill all instances of job")
-            os.Exit(1)
-        }
-    }
-    fmt.Println(resp.String())
+	monitor := &realis.Monitor{Client: r}
+	if resp.ResponseCode == aurora.ResponseCode_OK {
+		if ok, err := monitor.Instances(job.JobKey(), 0, 5, 50); !ok || err != nil {
+			fmt.Println("Unable to kill all instances of job")
+			os.Exit(1)
+		}
+	}
+	fmt.Println(resp.String())
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	git.apache.org/thrift.git v0.0.0-20161221203622-b2a4d4ae21c7
+	github.com/apache/thrift v0.13.0
 	github.com/fsnotify/fsnotify v1.4.3-0.20161026203122-fd9ec7deca8b // indirect
 	github.com/gogo/protobuf v0.0.0-20160824171236-909568be09de // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,32 +4,33 @@ go 1.13
 
 require (
 	git.apache.org/thrift.git v0.0.0-20161221203622-b2a4d4ae21c7
-	github.com/davecgh/go-spew v1.1.1-0.20171005155431-ecdeabc65495
-	github.com/fsnotify/fsnotify v1.4.3-0.20161026203122-fd9ec7deca8b
-	github.com/gogo/protobuf v0.0.0-20160824171236-909568be09de
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/hashicorp/hcl v0.0.0-20161101180025-6e968a3fcdcb
-	github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169
-	github.com/magiconair/properties v1.7.1-0.20160908093658-0723e352fa35
+	github.com/fsnotify/fsnotify v1.4.3-0.20161026203122-fd9ec7deca8b // indirect
+	github.com/gogo/protobuf v0.0.0-20160824171236-909568be09de // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/hashicorp/hcl v0.0.0-20161101180025-6e968a3fcdcb // indirect
+	github.com/kr/fs v0.0.0-20131111012553-2788f0dbd169 // indirect
+	github.com/magiconair/properties v1.7.1-0.20160908093658-0723e352fa35 // indirect
 	github.com/mesos/mesos-go v0.0.3-0.20161004192122-7228b13084ce
-	github.com/mitchellh/mapstructure v0.0.0-20161020161836-f3009df150da
-	github.com/paypal/gorealis v1.1.0
-	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222
-	github.com/pelletier/go-buffruneio v0.1.0
-	github.com/pelletier/go-toml v0.3.6-0.20160920070715-45932ad32dfd
-	github.com/pkg/errors v0.8.0
-	github.com/pkg/sftp v0.0.0-20160930220758-4d0e916071f6
-	github.com/samuel/go-zookeeper v0.0.0-20171117190445-471cd4e61d7a
+	github.com/mitchellh/mapstructure v0.0.0-20161020161836-f3009df150da // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/paypal/gorealis v1.22.3
+	github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222 // indirect
+	github.com/pelletier/go-buffruneio v0.1.0 // indirect
+	github.com/pelletier/go-toml v0.3.6-0.20160920070715-45932ad32dfd // indirect
+	github.com/pkg/errors v0.9.1
+	github.com/pkg/sftp v0.0.0-20160930220758-4d0e916071f6 // indirect
 	github.com/sirupsen/logrus v0.11.2
-	github.com/spf13/afero v0.0.0-20160919210114-52e4a6cfac46
-	github.com/spf13/cast v0.0.0-20160926084249-2580bc98dc0e
-	github.com/spf13/jwalterweatherman v0.0.0-20160311093646-33c24e77fb80
-	github.com/spf13/pflag v0.0.0-20161024131444-5ccb023bc27d
+	github.com/spf13/afero v0.0.0-20160919210114-52e4a6cfac46 // indirect
+	github.com/spf13/cast v0.0.0-20160926084249-2580bc98dc0e // indirect
+	github.com/spf13/jwalterweatherman v0.0.0-20160311093646-33c24e77fb80 // indirect
+	github.com/spf13/pflag v0.0.0-20161024131444-5ccb023bc27d // indirect
 	github.com/spf13/viper v0.0.0-20161029213352-651d9d916abc
-	github.com/stretchr/testify v1.2.1-0.20171231124224-87b1dfb5b2fa
-	golang.org/x/crypto v0.0.0-20161031180806-9477e0b78b9a
-	golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b
-	golang.org/x/sys v0.0.0-20161023150541-c200b10b5d5e
-	golang.org/x/text v0.0.0-20161027091323-a8b38433e35b
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20161031180806-9477e0b78b9a // indirect
+	golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b // indirect
+	golang.org/x/sys v0.0.0-20161023150541-c200b10b5d5e // indirect
+	golang.org/x/text v0.0.0-20161027091323-a8b38433e35b // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.0.0-20160928153709-a5b47d31c556
 )

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -32,7 +32,7 @@ import (
 	mesos "github.com/mesos/mesos-go/mesosproto"
 	log "github.com/sirupsen/logrus"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/plugin"
 	"github.com/paypal/dce-go/types"


### PR DESCRIPTION
Added support for using docker-compose to build dev environment.

I used a lot of pieces from gorealis to build this which doesn't have `docker-compose` installed on the mesos-agent which means we need to add `docker-compose` to the image and put it in the dcego dockerhub repo.

This also makes testing a lot better on our CI by allowing us to successfully launch a task.