### PR TITLE
0.7.6 DCE-GO

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -160,7 +160,7 @@ func GetLaunchTimeout() time.Duration {
 	// as well as integer which is existing value type
 	valStr := GetConfig().GetString(TIMEOUT)
 	if valInt, err := strconv.Atoi(valStr); err == nil {
-		return time.Duration(valInt)
+		return time.Duration(valInt) * time.Millisecond
 	}
 	duration, err := time.ParseDuration(valStr)
 	if err != nil {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,14 +1,14 @@
 launchtask:
-   podmonitorinterval: 10000
+   podmonitorinterval: 10s
    composehttptimeout: 300
    pullretry: 3
    maxretry: 3
-   retryinterval: 10000
-   timeout: 500000
+   retryinterval: 10s
+   timeout: 500s
    skippull: true
    composetrace: true
    debug: false
-   httptimeout: 20000
+   httptimeout: 20s
 plugins:
    pluginorder: general
 podStatusHooks:

--- a/dce/monitor/monitor.go
+++ b/dce/monitor/monitor.go
@@ -17,7 +17,6 @@ package monitor
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/paypal/dce-go/config"
 	"github.com/paypal/dce-go/types"
@@ -129,9 +128,9 @@ func MonitorPoller() {
 		logger.Printf("Infra container id: %s", infraContainerId)
 	}
 
-	res, err := wait.PollForever(time.Duration(config.GetPollInterval())*time.Millisecond, nil, wait.ConditionFunc(func() (string, error) {
+	res, err := wait.PollForever(config.GetPollInterval(), nil, func() (string, error) {
 		return podMonitor(infraContainerId).String(), nil
-	}))
+	})
 
 	logger.Printf("Pod Monitor Receiver : Received  message %s", res)
 

--- a/docs/how-to-develop.md
+++ b/docs/how-to-develop.md
@@ -163,11 +163,11 @@ func (ex *exampleExt) Shutdown(executor.ExecutorDriver) error {
     Here is an example of config.yaml
     ```
     launchtask:
-       podmonitorinterval: 10000
+       podmonitorinterval: 10s
        pullretry: 3
        maxretry: 3
-       retryinterval: 10000
-       timeout: 500000
+       retryinterval: 10s
+       timeout: 500s
     plugins:
        pluginorder: general,example
     cleanpod:
@@ -308,14 +308,14 @@ There are 2 types of configuration files:
 Main configuration file captures generic information relevant to compose executor. Details are outlined below.
 ```
 launchtask:
-   podmonitorinterval: 10000 # Periodic interval (in milisecond) at which pod is monitored. (Required)
+   podmonitorinterval: 10s   # Periodic interval at which pod is monitored. (Required)
    pullretry: 3              # Maximum retry count for pulling images. retry with backoff is 
                              # used on failure.(Optional, default value is 1.)
    maxretry: 3               # Maximum retry count for retrieving list of containers in a pod. 
                              # (Optional, defaults to 1) 
-   retryinterval: 10000      # Interval between each cmd retry
+   retryinterval: 10s        # Interval between each cmd retry
                              # (Optional, defaults to 10s)
-   timeout: 100000           # Timeout for pods get running. (Required)
+   timeout: 500s             # Timeout for pods get running. (Required)
 plugins:
    pluginorder: general      # Define the order of plugins will be executed. If you register your 
                              # plugin with name "example", you will have "general,example" as pluginorder. 
@@ -346,13 +346,13 @@ dockercomposeverbose: true                       # enable verbose mode for each 
  
 ```
 <!--
-podmonitorinterval: Periodic interval (in milisecond) at which pod is monitored. (Required)
+podmonitorinterval: Periodic interval at which pod is monitored. (Required, default is 10s)
 
 pullretry: Maximum retry count for pulling images. retry with backoff is used on failure.(Optional, default value is 1.)
 
 maxretry: Maximum retry count for retrieving list of containers in a pod. (Optional, default value is 1)
 
-timeout: Timeout for pods get running. (Required)
+timeout: Timeout for pods get running. (Required, default is 500s)
 
 pluginorder: Define the order of plugins will be executed. If you register your plugin with name "example", you will have "general,example" as pluginorder. This will be a critical configuration to get pod running successfully. (Required)
 

--- a/examples/vagrant/config/config.yaml
+++ b/examples/vagrant/config/config.yaml
@@ -1,8 +1,8 @@
 launchtask:
-   podmonitorinterval: 10000
+   podmonitorinterval: 10s
    pullretry: 3
    maxretry: 10
-   timeout: 500000
+   timeout: 500s
 plugins:
    pluginorder: general
 foldername: poddata

--- a/examples/vagrant/config/config_example.yaml
+++ b/examples/vagrant/config/config_example.yaml
@@ -1,8 +1,8 @@
 launchtask:
-   podmonitorinterval: 10000
+   podmonitorinterval: 10s
    pullretry: 3
    maxretry: 10
-   timeout: 500000
+   timeout: 500s
 plugins:
    pluginorder: general,example
 foldername: poddata

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -549,7 +549,7 @@ func ValidateCompose(files []string) error {
 		return err
 	}
 
-	err = waitUtil.WaitCmd(config.GetLaunchTimeout()*time.Millisecond, &types.CmdResult{
+	err = waitUtil.WaitCmd(config.GetLaunchTimeout(), &types.CmdResult{
 		Command: cmd,
 	})
 
@@ -584,7 +584,7 @@ func PullImage(files []string) error {
 		return err
 	}
 
-	err = waitUtil.WaitCmd(config.GetLaunchTimeout()*time.Millisecond, &types.CmdResult{
+	err = waitUtil.WaitCmd(config.GetLaunchTimeout(), &types.CmdResult{
 		Command: cmd,
 	})
 	if err != nil {
@@ -1081,7 +1081,7 @@ func HealthCheck(files []string, podServices map[string]bool, out chan<- string)
 	var containers []string
 	var healthCount int
 
-	interval := time.Duration(config.GetPollInterval())
+	interval := config.GetPollInterval()
 
 	// Convert pod services from map to array
 	var services []string

--- a/utils/wait/wait.go
+++ b/utils/wait/wait.go
@@ -172,7 +172,7 @@ func RetryCmd(retry int, cmd *exec.Cmd) ([]byte, error) {
 			if strings.Contains(err.Error(), "already started") {
 				return out, nil
 			}
-			time.Sleep(retryInterval * time.Duration((i+1)*factor) * time.Millisecond)
+			time.Sleep(retryInterval * time.Duration((i+1)*factor))
 			continue
 		}
 
@@ -221,7 +221,7 @@ func RetryCmdLogs(cmd *exec.Cmd, retry bool) ([]byte, error) {
 			}
 		}
 		log.Printf("cmd %s exits, retry...", _cmd.Args)
-		time.Sleep(retryInterval * time.Millisecond)
+		time.Sleep(retryInterval)
 	}
 	return out, err
 }


### PR DESCRIPTION
Today most duration config use type of integer, to make it more readable, update all duration related config under launchtask section from integer to duration string.

 A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"

What we have today
```
launchtask:
   podmonitorinterval: 10000
   retryinterval: 10000
   timeout: 500000
```

Update it to
```
launchtask:
   podmonitorinterval: 10s
   retryinterval: 10s
   timeout: 500s
```