### PR TITLE
Get label by full suffix match

### DIFF
--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -759,28 +759,9 @@ func ParseToContainerDetail(output string, healthcheck bool) (types.ContainerSta
 	return containerStatusDetails, nil
 }
 
-// GetLabel gets label by name
-func GetLabel(key string, taskInfo *mesos.TaskInfo) string {
-	var labelsList []*mesos.Label
-	labelsList = taskInfo.GetLabels().GetLabels()
-	var label *mesos.Label
-	for _, label = range labelsList {
-		if label.GetKey() == key {
-			return label.GetValue()
-		}
-		if strings.Contains(label.GetKey(), key) && strings.Contains(label.GetKey(), ".") {
-			arr := strings.Split(label.GetKey(), ".")
-			if arr[len(arr)-1] == key {
-				return label.GetValue()
-			}
-		}
-	}
-	return ""
-}
-
-// GetLabelByFullSuffix checks if the whole key is the suffix of a label
+// GetLabel checks if the whole key is the suffix of a label
 // and fetches the value of that label
-func GetLabelByFullSuffix(key string, taskInfo *mesos.TaskInfo) string {
+func GetLabel(key string, taskInfo *mesos.TaskInfo) string {
 	labelsList := taskInfo.GetLabels().GetLabels()
 	for _, label := range labelsList {
 		lKey, lVal := label.GetKey(), label.GetValue()

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -786,7 +786,7 @@ func GetLabelByFullSuffix(key string, taskInfo *mesos.TaskInfo) string {
 		lKey, lVal := label.GetKey(), label.GetValue()
 		if lKey == key {
 			return lVal
-		} else if len(lKey) > len(key) && lKey[len(lKey)-len(key):] == key && lKey[len(lKey)-len(key)-1] == '.' {
+		} else if len(lKey) > len(key) && strings.HasSuffix(lKey, key) && lKey[len(lKey)-len(key)-1] == '.' {
 			return lVal
 		}
 	}

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -179,7 +179,7 @@ func GetPodContainerIds(files []string) ([]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Errorln(os.Stderr, "reading standard input:", err)
+		log.Errorln("reading standard input:", err)
 	}
 	return containerIds, nil
 }
@@ -234,7 +234,7 @@ func GetContainerIdByService(files []string, service string) (string, error) {
 		id += scanner.Text()
 	}
 	if err := scanner.Err(); err != nil {
-		logger.Errorln(os.Stderr, "stderr: ", err)
+		logger.Errorln("stderr: ", err)
 		return "", err
 	}
 
@@ -260,7 +260,7 @@ func GetPodDetail(files []string, primaryContainerId string, healthcheck bool) {
 		log.Println(scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		log.Errorln(os.Stderr, "reading standard input:", err)
+		log.Errorln("reading standard input:", err)
 	}
 
 	if primaryContainerId != "" {
@@ -773,6 +773,20 @@ func GetLabel(key string, taskInfo *mesos.TaskInfo) string {
 			if arr[len(arr)-1] == key {
 				return label.GetValue()
 			}
+		}
+	}
+	return ""
+}
+
+// get label by full key suffix match
+func GetLabelByFullSuffix(key string, taskInfo *mesos.TaskInfo) string {
+	labelsList := taskInfo.GetLabels().GetLabels()
+	for _, label := range labelsList {
+		lKey, lVal := label.GetKey(), label.GetValue()
+		if lKey == key {
+			return lVal
+		} else if len(lKey) > len(key) && lKey[len(lKey)-len(key):] == key && lKey[len(lKey)-len(key)-1] == '.' {
+			return lVal
 		}
 	}
 	return ""

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -759,7 +759,7 @@ func ParseToContainerDetail(output string, healthcheck bool) (types.ContainerSta
 	return containerStatusDetails, nil
 }
 
-// get label by name
+// GetLabel gets label by name
 func GetLabel(key string, taskInfo *mesos.TaskInfo) string {
 	var labelsList []*mesos.Label
 	labelsList = taskInfo.GetLabels().GetLabels()
@@ -778,7 +778,8 @@ func GetLabel(key string, taskInfo *mesos.TaskInfo) string {
 	return ""
 }
 
-// get label by full key suffix match
+// GetLabelByFullSuffix checks if the whole key is the suffix of a label
+// and fetches the value of that label
 func GetLabelByFullSuffix(key string, taskInfo *mesos.TaskInfo) string {
 	labelsList := taskInfo.GetLabels().GetLabels()
 	for _, label := range labelsList {

--- a/utils/pod/pod_test.go
+++ b/utils/pod/pod_test.go
@@ -150,6 +150,8 @@ func TestKillContainer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestGetLabelByFullSuffix tests whether GetLabelByFullSuffix()
+// will break in case of an invalid key
 func TestGetLabelByFullSuffix(t *testing.T) {
 	key1 := "org.apache.aurora.metadata.port"
 	value1 := "9090"
@@ -199,7 +201,7 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 		{
 			name: "testInvalidLabel1",
 			args: args{
-				key:      "org.apache.aurora.metadata.comINVALID.genesis.registrator.port",
+				key:      "comINVALID.genesis.registrator.port",
 				taskInfo: taskInfo,
 			},
 			want: "",
@@ -207,7 +209,7 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 		{
 			name: "testInvalidLabel2",
 			args: args{
-				key:      "org.apache.aurora.metadata.INVALIDcom.genesis.registrator.port",
+				key:      "INVALIDcom.genesis.registrator.port",
 				taskInfo: taskInfo,
 			},
 			want: "",

--- a/utils/pod/pod_test.go
+++ b/utils/pod/pod_test.go
@@ -150,9 +150,9 @@ func TestKillContainer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestGetLabelByFullSuffix tests whether GetLabelByFullSuffix()
+// TestGetLabel tests whether GetLabel()
 // will break in case of an invalid key
-func TestGetLabelByFullSuffix(t *testing.T) {
+func TestGetLabel(t *testing.T) {
 	key1 := "org.apache.aurora.metadata.port"
 	value1 := "9090"
 	key2 := "org.apache.aurora.metadata.com.genesis.registrator.port"
@@ -199,7 +199,22 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 			want: value2,
 		},
 		{
-			name: "testInvalidLabel1",
+			name: "testOneWordKey",
+			args: args{
+				key:      "port",
+				taskInfo: taskInfo,
+			},
+			want: "9090",
+		}, {
+			name: "testMultiWordsKey",
+			args: args{
+				key:      "registrator.port",
+				taskInfo: taskInfo,
+			},
+			want: "9090",
+		},
+		{
+			name: "testInvalidKey1",
 			args: args{
 				key:      "comINVALID.genesis.registrator.port",
 				taskInfo: taskInfo,
@@ -207,7 +222,7 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "testInvalidLabel2",
+			name: "testInvalidKey2",
 			args: args{
 				key:      "INVALIDcom.genesis.registrator.port",
 				taskInfo: taskInfo,
@@ -215,7 +230,7 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "testInvalidLabel3",
+			name: "testInvalidKey3",
 			args: args{
 				key:      "org.apache.aurora.metadata.INVALID",
 				taskInfo: taskInfo,
@@ -223,9 +238,17 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "testInvalidLabel4",
+			name: "testInvalidKey4",
 			args: args{
 				key:      "org.apache.aurora.metadata",
+				taskInfo: taskInfo,
+			},
+			want: "",
+		},
+		{
+			name: "testInvalidKey5",
+			args: args{
+				key:      ".port",
 				taskInfo: taskInfo,
 			},
 			want: "",
@@ -233,8 +256,8 @@ func TestGetLabelByFullSuffix(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetLabelByFullSuffix(tt.args.key, taskInfo); got != tt.want {
-				t.Errorf("GetLabelByFullSuffix() = %v, want %v", got, tt.want)
+			if got := GetLabel(tt.args.key, taskInfo); got != tt.want {
+				t.Errorf("GetLabel() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The existing GetLabel() either does a full key match or else matches just the last part of a '.' delimited label.
- If label is "a.b.c.d" and key is "a.b.c.d", GetLabel() does a full match.
- If label is "a.b.c.d" and key is "c.d", GetLabel() checks only if the last part of the dot delimited label matches i.e., if "d" == "c.d". Providing just "d" as a key can be a risk since "d" maybe a well know name like 'port'.

To circumvent this issue, GetLabelByFullSuffix() can be used.
- If label is "a.b.c.d" and key is "a.b.c.d", GetLabelByFullSuffix() does a full match.
- If label is "a.b.c.d" and key is "c.d", GetLabelByFullSuffix() checks if "c.d" is the suffix of "a.b.c.d" and if "c.d" is preceeded by a "." in the label.