### PR TITLE
update launch flag before launch command

### DIFF
--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -323,8 +323,8 @@ func LaunchPod(files []string) (types.PodStatus, error) {
 
 	go dockerLogToPodLogFile(files, true)
 
-	err = cmd.Run()
 	LaunchCmdAttempted = true
+	err = cmd.Run()
 	log.Println("Updated the state of LaunchCmdAttempted to true.")
 	if err != nil {
 		log.Printf("POD_LAUNCH_FAIL -- Error running launch task command : %v", err)


### PR DESCRIPTION
In case launch command take long time however pods are actually added, we set LaunchCmdAttempted as true before run launch command. Otherwise, there could be pod leaks. 