### PR TITLE
update health check order

### DIFF
--- a/dce/monitor/plugin/default/monitor.go
+++ b/dce/monitor/plugin/default/monitor.go
@@ -57,6 +57,7 @@ func (m *monitor) Start(ctx context.Context) (types.PodStatus, error) {
 					pod.MonitorContainerList[i])
 				pod.MonitorContainerList = append(pod.MonitorContainerList[:i], pod.MonitorContainerList[i+1:]...)
 				i--
+				continue
 			}
 
 			if healthy == types.UNHEALTHY {

--- a/dce/monitor/plugin/default/monitor.go
+++ b/dce/monitor/plugin/default/monitor.go
@@ -52,20 +52,19 @@ func (m *monitor) Start(ctx context.Context) (types.PodStatus, error) {
 				return types.POD_FAILED, nil
 			}
 
+			if exitCode == 0 && !running {
+				logger.Infof("Removed finished(exit with 0) container %s from monitor list",
+					pod.MonitorContainerList[i])
+				pod.MonitorContainerList = append(pod.MonitorContainerList[:i], pod.MonitorContainerList[i+1:]...)
+				i--
+			}
+
 			if healthy == types.UNHEALTHY {
 				err = pod.PrintInspectDetail(pod.MonitorContainerList[i].ContainerId)
 				if err != nil {
 					log.Warnf("failed to get container detail: %s ", err)
 				}
 				return types.POD_FAILED, nil
-			}
-
-			if exitCode == 0 && !running {
-				logger.Infof("Removed finished(exit with 0) container %s from monitor list",
-					pod.MonitorContainerList[i])
-				pod.MonitorContainerList = append(pod.MonitorContainerList[:i], pod.MonitorContainerList[i+1:]...)
-				i--
-
 			}
 		}
 

--- a/utils/pod/pod.go
+++ b/utils/pod/pod.go
@@ -1190,6 +1190,7 @@ healthCheck:
 
 			if healthy == types.HEALTHY {
 				healthCount++
+				continue
 			}
 
 			if exitCode == 0 && !running {
@@ -1197,6 +1198,7 @@ healthCheck:
 				containers = append(containers[:i], containers[i+1:]...)
 				i--
 				healthCount--
+				continue
 			}
 
 			if healthy == types.UNHEALTHY {


### PR DESCRIPTION
In docker version 20, even container exit gracefully with 0 code, docker still marks health check as unhealthy. Before docker provide the fix, DCE is going to check exit code first and followed by health status of container.