### PR TITLE
Use container pid for force kill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "paypal-plugins"]
-	path = paypal-plugins
-	url = https://github.paypal.com/PaaS-R/dce-plugins.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "paypal-plugins"]
+	path = paypal-plugins
+	url = https://github.paypal.com/PaaS-R/dce-plugins.git

--- a/go.mod
+++ b/go.mod
@@ -51,3 +51,4 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.46.0
 	go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.46.0
 )
+replace github.paypal.com/PaaS-R/dce-plugins => ./paypal-plugins

--- a/go.mod
+++ b/go.mod
@@ -51,4 +51,3 @@ replace (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.46.0
 	go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.46.0
 )
-replace github.paypal.com/PaaS-R/dce-plugins => ./paypal-plugins

--- a/types/types.go
+++ b/types/types.go
@@ -188,4 +188,5 @@ type StepData struct {
 type SvcContainer struct {
 	ServiceName string
 	ContainerId string
+	Pid         string
 }

--- a/utils/pod/pod_test.go
+++ b/utils/pod/pod_test.go
@@ -16,7 +16,6 @@ package pod
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -91,12 +90,6 @@ func TestForceKill(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCMD(t *testing.T) {
-	err := fmt.Errorf("test")
-	err = errors.Wrapf(err, "test")
-	fmt.Println(err.Error())
-}
-
 func TestStopPod(t *testing.T) {
 	files := []string{"testdata/docker-long.yml"}
 	res, err := LaunchPod(files)
@@ -134,7 +127,7 @@ func TestGetContainerIdByService(t *testing.T) {
 }
 
 func TestKillContainer(t *testing.T) {
-	err := KillContainer("", "", "")
+	err := KillContainer("", types.SvcContainer{})
 	log.Println(err.Error())
 	assert.Error(t, err, "test kill invalid container")
 
@@ -147,9 +140,11 @@ func TestKillContainer(t *testing.T) {
 	id, err := wait.PollUntil(time.Duration(1)*time.Second, nil, time.Duration(5)*time.Second, wait.ConditionFunc(func() (string, error) {
 		return GetContainerIdByService(files, "redis")
 	}))
-	err = KillContainer("SIGUSR1", id, "")
+	err = KillContainer("SIGUSR1", types.SvcContainer{
+		ContainerId: id,
+	})
 	assert.NoError(t, err, "Test sending kill signal to container")
-	err = KillContainer("", id, "")
+	err = KillContainer("", types.SvcContainer{ContainerId: id})
 	assert.NoError(t, err)
 
 	config.GetConfig().Set(types.RM_INFRA_CONTAINER, true)


### PR DESCRIPTION
**Context** 
DCE always use docker command for shutdown the pod or send signal to the pod, however there will be container leaks when docker hangs and not able to proceed those docker commands.

**Solution**
Instead of using docker command, we use kill command when docker-compose stop failed